### PR TITLE
Add patterns blacklist

### DIFF
--- a/src/main/resources/docs/patterns.json
+++ b/src/main/resources/docs/patterns.json
@@ -2074,11 +2074,6 @@
       "category": "CodeStyle"
     },
     {
-      "patternId": "import_no-unresolved",
-      "level": "Info",
-      "category": "CodeStyle"
-    },
-    {
       "patternId": "import_order",
       "level": "Info",
       "category": "CodeStyle"

--- a/src/main/scala/codacy/eslint/ESLint.scala
+++ b/src/main/scala/codacy/eslint/ESLint.scala
@@ -67,8 +67,10 @@ object ESLint extends Tool {
   }
 
   private def parseToolResult(path: Path, outputFile: Path): Try[List[Result]] = {
-    val xmlParsed = Try(XML.loadFile(outputFile.toFile))
-    xmlParsed.map(parseToolResult)
+    Try {
+      val xmlParsed = XML.loadFile(outputFile.toFile)
+      parseToolResult(xmlParsed)
+    }
   }
 
   private def parseToolResult(outputXml: Elem): List[Result] = {

--- a/src/main/scala/codacy/eslint/ESLint.scala
+++ b/src/main/scala/codacy/eslint/ESLint.scala
@@ -22,6 +22,11 @@ object WarnResult {
 
 object ESLint extends Tool {
 
+  lazy val blacklist = Set(
+    "import_no-unresolved",
+    "node_no-missing-require"
+  )
+
   override def apply(path: Path, conf: Option[List[PatternDef]], files: Option[Set[Path]])(implicit spec: Spec): Try[List[Result]] = {
     Try {
       val filesToLint: List[String] = files.fold(List(path.toString)) {
@@ -67,9 +72,16 @@ object ESLint extends Tool {
   }
 
   private def parseToolResult(path: Path, outputFile: Path): Try[List[Result]] = {
+    def blacklisted(result: Result): Boolean = {
+      result match {
+        case issue: Issue => blacklist.contains(issue.patternId.value)
+        case _ => false
+      }
+    }
+
     Try {
       val xmlParsed = XML.loadFile(outputFile.toFile)
-      parseToolResult(xmlParsed)
+      parseToolResult(xmlParsed).filterNot(blacklisted)
     }
   }
 


### PR DESCRIPTION
Add import/no-unresolved and node/no-missing-require to the patterns blacklist

Those patterns need npm install, and our dockers run without internet, so we don't support them