### PR TITLE
Upgrade ESLint and Airbnb standard

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,8 +45,8 @@ def installAll (toolVersion: String) =
      |npm install -g npm@5 &&
      |npm install -g eslint@$toolVersion &&
      |npm install -g babel-eslint@8.0.0 &&
-     |npm install -g eslint-config-airbnb@15.1.0 &&
-     |npm install -g eslint-config-airbnb-base@12.0.0 &&
+     |npm install -g eslint-config-airbnb@16.1.0 &&
+     |npm install -g eslint-config-airbnb-base@12.1.0 &&
      |npm install -g eslint-plugin-import@2.7.0 &&
      |npm install -g eslint-plugin-jsx-a11y@5.1.1 &&
      |npm install -g eslint-plugin-react@7.2.1 &&

--- a/src/main/resources/docs/patterns.json
+++ b/src/main/resources/docs/patterns.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint",
-  "version": "4.7.1",
+  "version": "4.11.0",
   "patterns": [
     {
       "patternId": "comma-dangle",


### PR DESCRIPTION
Currently used Airbnb standard uses v15.1.0, which reports different errors than current version. Airbnb 16.1.0 (latest) however required at least eslint v4.8.0, so it needs to be upgraded as well.

Details in [support request](https://support.codacy.com/hc/en-us/requests/1735).

**Notes**
1. I am not a Scala programmer, I just tried to find relevant lines to upgrade. Might have forgotten to change something, somewhere...
2. Upgraded minor ESLint version. It should not break compatibility with any of existing plugins, but I have not tested it.