### PR TITLE
Added eslint-plugin-chai-expect version 1.1.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,6 +79,7 @@ def installAll(toolVersion: String) =
      |npm install -g eslint-plugin-drupal@0.3.1 &&
      |npm install -g eslint-plugin-lodash-fp@2.1.3 &&
      |npm install -g eslint-plugin-mocha@4.11.0 &&
+     |npm install -g eslint-plugin-chai-expect@1.1.1 &&
      |npm install -g eslint-plugin-mongodb@0.2.4 &&
      |npm install -g eslint-plugin-no-unsafe-innerhtml@1.0.16 &&
      |npm install -g eslint-plugin-security@1.4.0 &&


### PR DESCRIPTION
This is the error we are receiving within Codacy when using a custom `eslintrc.js` file.
<img width="715" alt="screen shot 2018-01-30 at 10 56 17 am" src="https://user-images.githubusercontent.com/6452107/35585215-3b1a16d0-05ac-11e8-9f59-80bb49c5983c.png">
