### PR TITLE
allow for sfdx patch changes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -102,7 +102,7 @@ def installAll(toolVersion: String) =
      |npm install -g eslint-config-rallycoding@3.2.0 &&
      |npm install -g eslint-config-react-app@2.1.0 &&
      |npm install -g eslint-plugin-jasmine@2.9.3 &&
-     |npm install -g eslint-plugin-sfdx@1.0.0 &&
+     |npm install -g eslint-plugin-sfdx@1.0 &&
      |npm install -g eslint-plugin-redux-saga@0.8.0 &&
      |rm -rf /tmp/* &&
      |rm -rf /var/cache/apk/*""".stripMargin.replaceAll(System.lineSeparator(), " ")


### PR DESCRIPTION
Changed `eslint-plugin-sfdx` install to allow for patch changes on the package while under active development.