### PR TITLE
update prettier to version 1.9.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,7 @@ def installAll(toolVersion: String) =
      |npm install -g lint-staged@4.0.2 &&
      |npm install -g eslint-config-dbk@2.0.0 &&
      |npm install -g eslint-config-google@0.9.1 &&
-     |npm install -g prettier@1.7.0 &&
+     |npm install -g prettier@1.9.2 &&
      |npm install -g eslint-plugin-prettier@2.6.0 &&
      |npm install -g eslint-config-prettier@2.9.0 &&
      |npm install -g eslint-config-signavio-test@2.0.0 &&


### PR DESCRIPTION
Hello,

This PR deals with #88 

`eslint-plugin-prettier` and `eslint-config-prettier` are already the latest version available so there is no need to update them. I put the latest version in `1.9` branch.

Thanks