### PR TITLE
Add eslint-config-gatsby-standard

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -104,7 +104,7 @@ def installAll(toolVersion: String) =
      |npm install -g eslint-plugin-jasmine@2.9.3 &&
      |npm install -g eslint-plugin-sfdx@1.0 &&
      |npm install -g eslint-plugin-redux-saga@0.8.0 &&
-     |npm install -g eslint-config-gatsby-standard@1.0.1 &&
+     |npm install -g eslint-config-gatsby-standard@1.2.0 &&
      |rm -rf /tmp/* &&
      |rm -rf /var/cache/apk/*""".stripMargin.replaceAll(System.lineSeparator(), " ")
 

--- a/build.sbt
+++ b/build.sbt
@@ -104,6 +104,7 @@ def installAll(toolVersion: String) =
      |npm install -g eslint-plugin-jasmine@2.9.3 &&
      |npm install -g eslint-plugin-sfdx@1.0 &&
      |npm install -g eslint-plugin-redux-saga@0.8.0 &&
+     |npm install -g eslint-config-gatsby-standard@1.0.1 &&
      |rm -rf /tmp/* &&
      |rm -rf /var/cache/apk/*""".stripMargin.replaceAll(System.lineSeparator(), " ")
 


### PR DESCRIPTION
This will make it possible for codacy to more easily lint GatsbyJS projects which are quite popular.
I was told to create a pull request here with the config in order to make codacy work for these plugins.