### PR TITLE
Dependency update for eslint-plugin-import, eslint-plugin-jsx-a11 and eslint-plugin-react

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,9 +45,9 @@ def installAll(toolVersion: String) =
      |npm install -g npm@5 &&
      |npm install -g eslint@${toolVersion} &&
      |npm install -g babel-eslint@8.0.3 &&
-     |npm install -g eslint-plugin-import@2.7.0 &&
-     |npm install -g eslint-plugin-jsx-a11y@5.1.1 &&
-     |npm install -g eslint-plugin-react@7.2.1 &&
+     |npm install -g eslint-plugin-import@2.9.0 &&
+     |npm install -g eslint-plugin-jsx-a11y@6.0.3 &&
+     |npm install -g eslint-plugin-react@7.8.2 &&
      |npm install -g webpack@3.6.0 &&
      |npm install -g eslint-plugin-jest@21.15.0 &&
      |npm install -g eslint-import-resolver-webpack@0.8.3 &&


### PR DESCRIPTION
We keep running into:

```
 Issue found: Definition for rule 'react/jsx-curly-brace-presence' was not found (react/jsx-curly-brace-presence)
```

With a create-react-app project. This is due to eslint-plugin-react being on an older version. See: https://github.com/yannickcr/eslint-plugin-react/blob/master/CHANGELOG.md

I've taken the liberty of updating all the dependencies that we use as well. to the latest version in 'create-react-app'.