### PR TITLE
Also run eslint on .jsm, .vue and .json files

### DIFF
--- a/src/main/scala/codacy/eslint/ESLint.scala
+++ b/src/main/scala/codacy/eslint/ESLint.scala
@@ -37,7 +37,7 @@ object ESLint extends Tool {
 
       val command = List("eslint") ++
         (if (configuration.nonEmpty) Some("--no-eslintrc") else None) ++
-        List("-f", "checkstyle", "--ext", ".js", "--ext", ".jsx", "-o", s"${outputFile.toJava.getCanonicalPath}") ++ toolConfiguration ++ filesToLint
+        List("-f", "checkstyle", "--ext", ".js", "--ext", ".jsm", "--ext", ".jsx", "--ext", ".vue", "--ext", ".json", "-o", s"${outputFile.toJava.getCanonicalPath}") ++ toolConfiguration ++ filesToLint
 
       CommandRunner.exec(command, Some(File(source.path).toJava)) match {
         case Right(resultFromTool) =>

--- a/src/main/scala/codacy/eslint/ESLint.scala
+++ b/src/main/scala/codacy/eslint/ESLint.scala
@@ -37,7 +37,7 @@ object ESLint extends Tool {
 
       val command = List("eslint") ++
         (if (configuration.nonEmpty) Some("--no-eslintrc") else None) ++
-        List("-f", "checkstyle", "--ext", ".js", "--ext", ".jsm", "--ext", ".jsx", "--ext", ".vue", "--ext", ".json", "-o", s"${outputFile.toJava.getCanonicalPath}") ++ toolConfiguration ++ filesToLint
+        List("-f", "checkstyle", "--ext", ".js,.jsm,.jsx,.vue,.json", "-o", s"${outputFile.toJava.getCanonicalPath}") ++ toolConfiguration ++ filesToLint
 
       CommandRunner.exec(command, Some(File(source.path).toJava)) match {
         case Right(resultFromTool) =>


### PR DESCRIPTION
* Node.js requires ECMAScript modules (ESM) to be in .mjs files
* Vue single file components have .vue file extension
  (checked with eslint-plugin-vue)
* JSON files can be checked with eslint-plugin-json (see #99)