### PR TITLE
Update eslint-plugin-react to version 7.11.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ def installAll(toolVersion: String) =
      |npm install -g babel-eslint@10.0.1 &&
      |npm install -g eslint-plugin-import@2.9.0 &&
      |npm install -g eslint-plugin-jsx-a11y@6.1.2 &&
-     |npm install -g eslint-plugin-react@7.8.2 &&
+     |npm install -g eslint-plugin-react@7.11.1 &&
      |npm install -g webpack@3.6.0 &&
      |npm install -g eslint-plugin-jest@21.15.0 &&
      |npm install -g eslint-import-resolver-webpack@0.8.3 &&


### PR DESCRIPTION
Currently at 7.8.2, and some new rules have been added. This version has been out for 4 months, so it should be safe.