### PR TITLE
bump: ESLint from 5.8.0  to 5.16.0 FT7181

### DIFF
--- a/src/main/resources/docs/description/description.json
+++ b/src/main/resources/docs/description/description.json
@@ -1,5 +1,17 @@
 [
   {
+    "patternId": "no-useless-catch",
+    "title": "Disallow unnecessary catch clauses",
+    "description": "Disallow unnecessary catch clauses.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "prefer-named-capture-group",
+    "title": "Suggest using named capture group in regular expression ",
+    "description": "Enforce using named capture group in regular expression.",
+    "timeToFix": 5
+  },
+  {
     "patternId": "comma-dangle",
     "title": "Enforce Dangling Commas",
     "description": "Enforces consistent use of trailing commas in object and array literals",

--- a/src/main/resources/docs/description/no-useless-catch.md
+++ b/src/main/resources/docs/description/no-useless-catch.md
@@ -1,0 +1,34 @@
+A catch clause that only rethrows the original error is redundant, and has no effect on the runtime behavior of the program. These redundant clauses can be a source of confusion and code bloat, so it's better to disallow these unnecessary catch clauses.
+
+```
+//Bad:
+try {
+  doSomethingThatMightThrow();
+} catch (e) {
+  throw e;
+}
+
+try {
+  doSomethingThatMightThrow();
+} catch (e) {
+  throw e;
+} finally {
+  cleanUp();
+}
+
+//Good:
+try {
+  doSomethingThatMightThrow();
+} catch (e) {
+  doSomethingBeforeRethrow();
+  throw e;
+}
+
+try {
+  doSomethingThatMightThrow();
+} catch (e) {
+  handleError(e);
+}
+```
+
+[Source](https://eslint.org/docs/rules/no-useless-catch)

--- a/src/main/resources/docs/description/prefer-named-capture-group.md
+++ b/src/main/resources/docs/description/prefer-named-capture-group.md
@@ -1,0 +1,19 @@
+This rule is aimed at using named capture groups instead of numbered capture groups in regular expressions.
+
+```
+//Bad:
+const foo = /(ba[rz])/;
+const bar = new RegExp('(ba[rz])');
+const baz = RegExp('(ba[rz])');
+
+foo.exec('bar')[1]; // Retrieve the group result.
+
+//Good:
+const foo = /(?<id>ba[rz])/;
+const bar = new RegExp('(?<id>ba[rz])');
+const baz = RegExp('(?<id>ba[rz])');
+
+foo.exec('bar').groups.id; // Retrieve the group result.
+```
+
+[Source](https://eslint.org/docs/rules/prefer-named-capture-group)

--- a/src/main/resources/docs/patterns.json
+++ b/src/main/resources/docs/patterns.json
@@ -1,7 +1,17 @@
 {
   "name": "eslint",
-  "version": "5.8.0",
+  "version": "5.16.0",
   "patterns": [
+    {
+      "patternId": "no-useless-catch",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "prefer-named-capture-group",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
     {
       "patternId": "comma-dangle",
       "level": "Warning",

--- a/src/main/resources/docs/tests/no-useless-catch.js
+++ b/src/main/resources/docs/tests/no-useless-catch.js
@@ -1,0 +1,6 @@
+//#Patterns: no-useless-catch
+
+//#Info: no-useless-catch
+try {} catch (err) { throw err; }
+//#Info: no-useless-catch
+try {} catch (err) { throw err; } finally {}

--- a/src/main/resources/docs/tests/prefer-named-capture-group.js
+++ b/src/main/resources/docs/tests/prefer-named-capture-group.js
@@ -1,0 +1,6 @@
+//#Patterns: prefer-named-capture-group
+
+//#Info: prefer-named-capture-group
+new RegExp('/([0-9]{4})/');
+//#Info: prefer-named-capture-group
+new RegExp('/([0-9]{4})-(\\\\w{5})/');

--- a/src/main/resources/docs/tests/prefer-named-capture-group.js
+++ b/src/main/resources/docs/tests/prefer-named-capture-group.js
@@ -1,0 +1,4 @@
+//#Patterns: prefer-named-capture-group
+
+//#Info: prefer-named-capture-group
+new RegExp('/([0-9]{4})-(\\\\w{5})/');


### PR DESCRIPTION
This introduces two new rules, 'no-useless-catch' and 'prefer-named-capture-group'.