### PR TITLE
add eslint-plugin-compat plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -109,6 +109,7 @@ def installAll(toolVersion: String) =
      |npm install -g eslint-plugin-react-intl@1.1.2 &&
      |npm install -g eslint-plugin-json@1.2.1 &&
      |npm install -g eslint-plugin-cypress@2.0.1 &&
+     |npm install -g eslint-plugin-compat@1.0.2 &&
      |npm install -g @prodigy/eslint-config-prodigy &&
      |npm install -g eslint-plugin-ember-suave@1.0.0 &&
      |npm install -g typescript@3.4.1 &&


### PR DESCRIPTION
Adds support for eslint compat plugin which allows us to lint for errors based on supported browser versions.