### PR TITLE
bump: upgraded requested packages to their latest versions FT-7268

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,15 +40,15 @@ toolVersion := {
 def installAll(toolVersion: String) =
   s"""apk update &&
      |apk add bash curl nodejs-npm &&
-     |npm install -g npm@5 &&
+     |npm install -g npm@6 &&
      |npm install -g eslint@$toolVersion &&
      |npm install -g babel-eslint@10.0.1 &&
-     |npm install -g eslint-plugin-import@2.9.0 &&
-     |npm install -g eslint-plugin-jsx-a11y@6.1.2 &&
-     |npm install -g eslint-plugin-react@7.11.1 &&
+     |npm install -g eslint-plugin-import@2.17.2 &&
+     |npm install -g eslint-plugin-jsx-a11y@6.2.1 &&
+     |npm install -g eslint-plugin-react@7.13.0 &&
      |npm install -g eslint-plugin-react-native@3.5.0 &&
-     |npm install -g webpack@3.6.0 &&
-     |npm install -g eslint-plugin-jest@21.15.0 &&
+     |npm install -g webpack@4.32.2 &&
+     |npm install -g eslint-plugin-jest@22.6.4 &&
      |npm install -g eslint-import-resolver-webpack@0.8.3 &&
      |npm install -g eslint-import-resolver-node@0.3.1 &&
      |npm install -g eslint-config-airbnb-base@13.1.0 &&
@@ -66,15 +66,15 @@ def installAll(toolVersion: String) =
      |npm install -g eslint-config-standard@10.2.1 &&
      |npm install -g eslint-config-standard-react@7.0.2 &&
      |npm install -g eslint-config-strongloop@2.1.0 &&
-     |npm install -g eslint-plugin-vue@5.0.0 &&
+     |npm install -g eslint-plugin-vue@5.2.2 &&
      |npm install -g eslint-config-vue@2.0.2 &&
      |npm install -g eslint-config-winedirect@1.0.0 &&
-     |npm install -g lint-staged@4.0.2 &&
+     |npm install -g lint-staged@8.1.7 &&
      |npm install -g eslint-config-dbk@2.0.0 &&
      |npm install -g eslint-config-google@0.9.1 &&
-     |npm install -g prettier@1.15.2 &&
-     |npm install -g eslint-plugin-prettier@3.0.0 &&
-     |npm install -g eslint-config-prettier@3.3.0 &&
+     |npm install -g prettier@1.17.1 &&
+     |npm install -g eslint-plugin-prettier@3.1.0 &&
+     |npm install -g eslint-config-prettier@4.3.0 &&
      |npm install -g eslint-config-signavio-test@2.0.0 &&
      |npm install -g eslint-config-signavio@3.2.0 &&
      |npm install -g eslint-config-simplifield@7.0.1 &&
@@ -93,7 +93,7 @@ def installAll(toolVersion: String) =
      |npm install -g eslint-plugin-angular@3.1.1 &&
      |npm install -g eslint-plugin-babel@5.2.0 &&
      |npm install -g eslint-plugin-backbone@2.1.1 &&
-     |npm install -g eslint-plugin-flowtype@2.35.1 &&
+     |npm install -g eslint-plugin-flowtype@3.9.1 &&
      |npm install -g eslint-plugin-html@3.2.2 &&
      |npm install -g eslint-plugin-lodash@2.4.5 &&
      |npm install -g eslint-plugin-meteor@4.1.4 &&
@@ -108,13 +108,13 @@ def installAll(toolVersion: String) =
      |npm install -g eslint-config-gatsby-standard@1.2.0 &&
      |npm install -g eslint-plugin-react-intl@1.1.2 &&
      |npm install -g eslint-plugin-json@1.2.1 &&
-     |npm install -g eslint-plugin-cypress@2.0.1 &&
+     |npm install -g eslint-plugin-cypress@2.2.1 &&
      |npm install -g eslint-plugin-chai-friendly@0.4.1 &&
      |npm install -g @prodigy/eslint-config-prodigy &&
      |npm install -g eslint-plugin-ember-suave@1.0.0 &&
-     |npm install -g typescript@3.4.1 &&
-     |npm install -g @typescript-eslint/eslint-plugin@1.6.0 &&
-     |npm install -g @typescript-eslint/parser@1.6.0 &&
+     |npm install -g typescript@3.4.5 &&
+     |npm install -g @typescript-eslint/eslint-plugin@1.9.0 &&
+     |npm install -g @typescript-eslint/parser@1.9.0 &&
      |npm install -g eslint-plugin-relay@1.3.1 &&
      |rm -rf /tmp/* &&
      |rm -rf /var/cache/apk/*""".stripMargin

--- a/src/main/resources/docs/description/assertion-before-screenshot.md
+++ b/src/main/resources/docs/description/assertion-before-screenshot.md
@@ -1,0 +1,18 @@
+If you take screenshots without assertions then you may get different screenshots depending on timing.
+
+For example, if clicking a button makes some network calls and upon success, renders something, then the screenshot may sometimes have the new render and sometimes not.
+
+This rule checks there is an assertion making sure your application state is correct before doing a screenshot. This makes sure the result of the screenshot will be consistent.
+
+```
+//Bad:
+cy.visit('myUrl');
+cy.screenshot();
+
+//Good:
+cy.visit('myUrl');
+cy.get('[data-test-id="my-element"]').should('be.visible');
+cy.screenshot();
+```
+
+[Source](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/assertion-before-screenshot.md)

--- a/src/main/resources/docs/description/control-has-associated-label.md
+++ b/src/main/resources/docs/description/control-has-associated-label.md
@@ -1,0 +1,19 @@
+Enforce that a control (an interactive element) has a text label.
+
+There are two supported ways to supply a control with a text label:
+
+Provide text content inside the element.
+Use the aria-label attribute on the element, with a text value.
+Use the aria-labelledby attribute on the element, and point the IDREF value to an element with an accessible label.
+Alternatively, with an img tag, you may use the alt attribute to supply a text description of the image.
+The rule is permissive in the sense that it will assume that expressions will eventually provide a label. So an element like this will pass.
+
+```
+//Bad:
+<button>{maybeSomethingThatContainsALabel}</button>
+
+//Good:
+<button type="button">{maybeSomethingThatContainsALabel}</button>
+```
+
+[Source](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/ead1767330766b26cba26faab901b75ac56402f4/docs/rules/control-has-associated-label.md)

--- a/src/main/resources/docs/description/description.json
+++ b/src/main/resources/docs/description/description.json
@@ -1,5 +1,223 @@
 [
   {
+    "patternId": "no-assigning-return-values",
+    "title": "No Assigning return values",
+    "description": "You rarely have to ever use const, let, or var in Cypress. If you’re using them, it’s usually a sign you’re doing it wrong.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "no-unnecessary-waiting",
+    "title": "Unnecessary wait for cy.request()",
+    "description": "Waiting here is unnecessary since the cy.request() command will not resolve until it receives a response from your server.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "assertion-before-screenshot",
+    "title": "Assertion Before Screenshot",
+    "description": "Prevents taking screenshots without assertions.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "import_no-cycle",
+    "title": "No import cycle",
+    "description": "Prevents resolvable path back to this module via its dependencies.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "import_no-named-export",
+    "title": "No named exports",
+    "description": "Prohibit named exports",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "import_no-duplicates",
+    "title": "No duplicate import statements",
+    "description": "Reports if a resolved path is imported more than once",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "import_no-useless-path-segments",
+    "title": "No useless import path segments",
+    "description": "Prevent unnecessary path segments in import and require statements",
+    "timeToFix": 5,
+    "parameters": [
+      {
+        "name": "noUselessIndex",
+        "description": "If you want to detect unnecessary /index or /index.js imports in your paths, you can enable the option noUselessIndex. [true, false]"
+      }
+    ]
+  },
+  {
+    "patternId": "import_prefer-inline-snapshots",
+    "title": "Suggest using inline snapshots",
+    "description": "Triggers a warning if toMatchSnapshot() or toThrowErrorMatchingSnapshot is used to capture a snapshot",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "vue_array-bracket-spacing",
+    "title": "Vue - Array bracket spacing",
+    "description": "Enforce consistent spacing inside array brackets",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "vue_arrow-spacing",
+    "title": "Vue - Arrow spacing",
+    "description": "Enforce consistent spacing before and after the arrow in arrow functions",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "vue_block-spacing",
+    "title": "Vue - Block spacing",
+    "description": "Disallow or enforce spaces inside of blocks after opening block and before closing block",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "vue_brace-style",
+    "title": "Vue - Brace style",
+    "description": "Enforce consistent brace style for blocks",
+    "timeToFix": 5,
+    "parameters": [
+      {
+        "name": "unnamedParam",
+        "description": "Brace style to enforces. [1tbs, stroustrup, allman]"
+      },
+      {
+        "name": "allowSingleLine",
+        "description": "Allows the opening and closing braces for a block to be on the same line. [true, false]"
+      }
+    ]
+  },
+  {
+    "patternId": "vue_camelcase",
+    "title": "Vue - Camelcase",
+    "description": "Enforce camelcase naming convention",
+    "timeToFix": 5,
+    "parameters": [
+      {
+        "name": "properties",
+        "description": "Specifies if this pattern should always check for property names [always, never]"
+      }
+    ]
+  },
+  {
+    "patternId": "vue_comma-dangle",
+    "title": "Vue - Comma dangle",
+    "description": "Require or disallow trailing commas",
+    "timeToFix": 5,
+    "parameters": [
+      {
+        "name": "comma-dangle",
+        "description": "The style of trailing commas [never, always, always-multiline]"
+      }
+    ]
+  },
+  {
+    "patternId": "vue_eqeqeq",
+    "title": "Vue - Eqeqeq",
+    "description": "Require the use of === and !==",
+    "timeToFix": 5,
+    "parameters": [
+      {
+        "name": "unnamedParam",
+        "description": "The style of equality to follow [smart, allow-null]"
+      }
+    ]
+  },
+  {
+    "patternId": "vue_key-spacing",
+    "title": "Vue - Key spacing",
+    "description": "Enforce consistent spacing between keys and values in object literal properties",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "vue_match-component-file-name",
+    "title": "Vue - Match component file name",
+    "description": "Require component name property to match its file name",
+    "timeToFix": 5,
+    "parameters": [
+      {
+        "name": "shouldMatchCase",
+        "description": "Indicating if component's name should also match its file name case. [true, false]"
+      },
+      {
+        "name": "extensions",
+        "description": "any combination of \".jsx\", \".vue\" and \".js\" extensions. [jsx, vue, js"
+      }
+    ]
+  },
+  {
+    "patternId": "vue_no-boolean-default",
+    "title": "Vue - No boolean default",
+    "description": "Disallow boolean defaults",
+    "timeToFix": 5,
+    "parameters": [
+      {
+        "name": "unnamedParam",
+        "description": "Enforces that the default can be set but must be set to false. [true, false]"
+      }
+    ]
+  },
+  {
+    "patternId": "vue_no-restricted-syntax",
+    "title": "Vue - No restricted syntax",
+    "description": "Disallow specified syntax",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "vue_object-curly-spacing",
+    "title": "Vue - Object curly spacing",
+    "description": "Enforce consistent spacing inside braces",
+    "timeToFix": 5,
+    "parameters": [
+      {
+        "name": "unnamedParam",
+        "description": "Specifies if you always want a space inside of curly braces [always, never]"
+      }
+    ]
+  },
+  {
+    "patternId": "vue_require-direct-export",
+    "title": "Vue - Require direct export",
+    "description": "Require the component to be directly exported",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "vue_space-infix-ops",
+    "title": "Vue - Space infix ops",
+    "description": "Require spacing around infix operators",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "vue_space-unary-ops",
+    "title": "Vue - Space unary ops",
+    "description": "Enforce consistent spacing before or after unary operators",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "vue_v-on-function-call",
+    "title": "Vue - On function call",
+    "description": "Enforce or forbid parentheses after method calls without arguments in v-on directives",
+    "timeToFix": 5,
+    "parameters": [
+      {
+        "name": "unnamedParam",
+        "description": "Always use parentheses in v-on directives. Never use parentheses in v-on directives for method calls without arguments [always, never]"
+      }
+    ]
+  },
+  {
+    "patternId": "no-jasmin-globals",
+    "title": "Disallow Jasmine globals",
+    "description": "Reports on any usage of Jasmine globals which is not ported to Jest",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "control-has-associated-label",
+    "title": "Controls have associated labels",
+    "description": "Enforce that a control (an interactive element) has a text label",
+    "timeToFix": 5
+  },
+  {
     "patternId": "no-useless-catch",
     "title": "Disallow unnecessary catch clauses",
     "description": "Disallow unnecessary catch clauses.",

--- a/src/main/resources/docs/description/no-assigning-return-values.md
+++ b/src/main/resources/docs/description/no-assigning-return-values.md
@@ -1,0 +1,24 @@
+Many first time users look at Cypress code and think it runs synchronously.
+
+We see new users commonly write code that looks like this:
+
+```
+// DONT DO THIS. IT DOES NOT WORK
+// THE WAY YOU THINK IT DOES.
+
+const button = cy.get('button')
+
+const form = cy.get('form')
+
+// nope, fails
+button.click()
+```
+
+If you’re familiar with Cypress commands already, but find yourself using const, let, or var then you’re typically 
+trying to do one of two things:
+
+You’re trying to store and compare values such as text, classes, attributes.
+You’re trying to share values between tests and hooks like before and beforeEach.
+For working with either of these patterns, please read our Variables and Aliases guide.
+
+[Source](https://docs.cypress.io/guides/references/best-practices.html#Assigning-Return-Values)

--- a/src/main/resources/docs/description/no-cycle.md
+++ b/src/main/resources/docs/description/no-cycle.md
@@ -1,0 +1,14 @@
+Ensures that there is no resolvable path back to this module via its dependencies.
+
+This includes cycles of depth 1 (imported module imports me) to Infinity, if the maxDepth option is not set.
+
+```
+// dep-b.js
+import './dep-a.js'
+
+export function b() { /* ... */ }
+
+// dep-a.js
+//Bad:
+import { b } from './dep-b.js' // reported: Dependency cycle detected.
+```

--- a/src/main/resources/docs/description/no-duplicates.md
+++ b/src/main/resources/docs/description/no-duplicates.md
@@ -1,0 +1,27 @@
+Reports if a resolved path is imported more than once.
+
+ESLint core has a similar rule (no-duplicate-imports), but this version is different in two key ways:
+
+* the paths in the source code don't have to exactly match, they just have to point to the same module on the 
+filesystem. (i.e. ./foo and ./foo.js)
+
+* this version distinguishes Flow type imports from standard imports.
+
+```
+//Bad:
+import SomeDefaultClass from './mod'
+
+// oops, some other import separated these lines
+import foo from './some-other-mod'
+
+import * as names from './mod'
+
+// will catch this too, assuming it is the same target module
+import { something } from './mod.js'
+
+//Good:
+import SomeDefaultClass, * as names from './mod'
+import type SomeType from './mod'
+```
+
+[Source](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md)

--- a/src/main/resources/docs/description/no-jasmine-globals.md
+++ b/src/main/resources/docs/description/no-jasmine-globals.md
@@ -1,0 +1,23 @@
+This rule reports on any usage of Jasmine globals which is not ported to Jest,
+and suggests alternative from Jest's own API.
+
+`jest` uses `jasmine` as a test runner. A side effect of this is that both a
+`jasmine` object, and some jasmine-specific globals, are exposed to the test
+environment. Most functionality offered by Jasmine has been ported to Jest, and
+the Jasmine globals will stop working in the future. Developers should therefor
+migrate to Jest's documented API instead of relying on the undocumented Jasmine
+API.
+
+```
+//Bad:
+test('my test', () => {
+  spyOn(some, 'object');
+});
+
+//Good:
+test('my test', () => {
+  jest.spyOn(some, 'object');
+});
+```
+
+[Source](https://github.com/jest-community/eslint-plugin-jest/blob/7707e1449e44d24de3507c0653fd5f3a9e3c0735/docs/rules/no-jasmine-globals.md)

--- a/src/main/resources/docs/description/no-named-export.md
+++ b/src/main/resources/docs/description/no-named-export.md
@@ -1,0 +1,13 @@
+Prohibit named exports. Mostly an inverse of no-default-export.
+
+```
+//Bad:
+// There is only a single module export and it's a named export.
+export const foo = 'foo';
+
+//Good:
+// There is only a single module export and it's a default export.
+export default 'bar';
+```
+
+[Source](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-export.md)

--- a/src/main/resources/docs/description/no-unnecessary-waiting.md
+++ b/src/main/resources/docs/description/no-unnecessary-waiting.md
@@ -1,0 +1,16 @@
+In Cypress, you almost never need to use cy.wait() for an arbitrary amount of time. If you are finding yourself doing this, there is likely a much better, simpler way.
+
+```
+//Bad:
+cy.request('http://localhost:8080/db/seed')
+cy.wait(5000)
+
+//Good:
+cy.server()
+cy.route('GET', /users/, [{ 'name': 'Maggy' }, { 'name': 'Joan' }]).as('getUsers')
+cy.get('#fetch').click()
+cy.wait('@getUsers')     // <--- wait explicitly for this route to finish
+cy.get('table tr').should('have.length', 2) 
+```
+
+[Source](https://docs.cypress.io/guides/references/best-practices.html#Unnecessary-Waiting)

--- a/src/main/resources/docs/description/no-useless-path-segments.md
+++ b/src/main/resources/docs/description/no-useless-path-segments.md
@@ -1,0 +1,25 @@
+Use this rule to prevent unnecessary path segments in import and require statements.
+
+Given the following folder structure:
+```
+my-project
+├── app.js
+├── footer.js
+├── header.js
+└── helpers.js
+└── helpers
+    └── index.js
+└── pages
+    ├── about.js
+    ├── contact.js
+    └── index.js 
+```
+```
+//Bad:
+import "./../pages/about.js";
+
+//Good:
+import "./pages/about";
+```
+
+[Source](https://github.com/benmosher/eslint-plugin-import/blob/206d67653c0d6cd087a51233f81d911fd347ca8e/docs/rules/no-useless-path-segments.md)

--- a/src/main/resources/docs/description/prefer-inline-snapshots.md
+++ b/src/main/resources/docs/description/prefer-inline-snapshots.md
@@ -1,0 +1,11 @@
+In order to make snapshot tests more managable and reviewable toMatchInlineSnapshot() and toThrowErrorMatchingInlineSnapshot should be used to write the snapshots inline in the test file.
+
+```
+//Bad:
+expect(obj).toMatchSnapshot();
+
+//Good:
+expect(obj).toMatchInlineSnapshot();
+```
+
+[Source](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/prefer-inline-snapshots.md)

--- a/src/main/resources/docs/description/vue_array-bracket-spacing.md
+++ b/src/main/resources/docs/description/vue_array-bracket-spacing.md
@@ -1,0 +1,17 @@
+Enforce consistent spacing inside array brackets
+
+This rule is the same rule as core array-bracket-spacing rule but it applies to the expressions in `<template>`.
+
+```
+//Bad:
+var arr = [ 'foo', 'bar' ];
+var [ x, y ] = z;
+var arr = [ 'foo', 'bar'];
+
+//Good:
+var arr = ['foo', 'bar'];
+var [x, y] = z;
+var arr = ['foo', 'bar'];
+```
+
+[Source](https://eslint.vuejs.org/rules/array-bracket-spacing.html#vue-array-bracket-spacing)

--- a/src/main/resources/docs/description/vue_arrow-spacing.md
+++ b/src/main/resources/docs/description/vue_arrow-spacing.md
@@ -1,0 +1,19 @@
+Enforce consistent spacing before and after the arrow in arrow functions
+
+This rule is the same rule as core arrow-spacing rule but it applies to the expressions in `<template>`.
+
+```
+//Bad: 
+{
+"before": false, "after": false }
+(a)=>{
+}
+
+//Good: 
+{
+"before": true, "after": true }
+(a) => {
+}
+```
+
+[Source](https://eslint.vuejs.org/rules/arrow-spacing.html#vue-arrow-spacing)

--- a/src/main/resources/docs/description/vue_block-spacing.md
+++ b/src/main/resources/docs/description/vue_block-spacing.md
@@ -1,0 +1,15 @@
+Disallow or enforce spaces inside of blocks after opening block and before closing block
+
+This rule is the same rule as core block-spacing rule but it applies to the expressions in `<template>`.
+
+```
+//Bad:
+function foo() {return true;} 
+if (foo) { bar = 0;}
+
+//Good:
+function foo() { return true; }
+if (foo) { bar = 0; }
+```
+
+[Source](https://eslint.vuejs.org/rules/block-spacing.html#vue-block-spacing)

--- a/src/main/resources/docs/description/vue_brace-style.md
+++ b/src/main/resources/docs/description/vue_brace-style.md
@@ -1,0 +1,18 @@
+Enforce consistent brace style for blocks
+
+This rule is the same rule as core brace-style rule but it applies to the expressions in `<template>`.
+
+```
+//Bad with 1tbs:
+function foo()
+{
+  return true;
+}
+
+//Good with 1tbs:
+function foo() {
+  return true;
+}
+```
+
+[Source](https://eslint.vuejs.org/rules/brace-style.html#vue-brace-style)

--- a/src/main/resources/docs/description/vue_camelcase.md
+++ b/src/main/resources/docs/description/vue_camelcase.md
@@ -1,0 +1,13 @@
+Enforce camelcase naming convention
+
+This rule is the same rule as core camelcase rule but it applies to the expressions in `<template>`.
+
+```
+//Bad:
+var my_favorite_color = "#112C85";
+
+//Good:
+var myFavoriteColor  = "#112C85";
+```
+
+[Source](https://eslint.vuejs.org/rules/camelcase.html#vue-camelcase)

--- a/src/main/resources/docs/description/vue_comma-dangle.md
+++ b/src/main/resources/docs/description/vue_comma-dangle.md
@@ -1,0 +1,19 @@
+Require or disallow trailing commas
+
+This rule is the same rule as core comma-dangle rule but it applies to the expressions in `<template>`.
+
+```
+//Bad:
+var foo = {
+    bar: "baz",
+    qux: "quux",
+};
+
+//Good:
+var foo = {
+    bar: "baz",
+    qux: "quux"
+};
+```
+
+[Source](https://eslint.vuejs.org/rules/comma-dangle.html#vue-comma-dangle)

--- a/src/main/resources/docs/description/vue_eqeqeq.md
+++ b/src/main/resources/docs/description/vue_eqeqeq.md
@@ -1,0 +1,20 @@
+Require the use of === and !==
+
+This rule is the same rule as core eqeqeq rule but it applies to the expressions in `<template>`.
+
+```
+//Bad:
+	a == b 
+	foo == true
+	bananas != 1
+	value == undefined
+	
+//Good:
+	typeof foo === 'undefined'
+	'hello' !== 'world'
+	0 === 0
+	true === true
+	foo === null
+```
+
+[Source](https://eslint.vuejs.org/rules/eqeqeq.html#vue-eqeqeq)

--- a/src/main/resources/docs/description/vue_key-spacing.md
+++ b/src/main/resources/docs/description/vue_key-spacing.md
@@ -1,0 +1,51 @@
+Enforce consistent spacing between keys and values in object literal properties
+
+This rule is the same rule as core key-spacing rule but it applies to the expressions in `<template>`.
+
+```
+//Good with "beforeColon" false and "afterColon" true
+var obj = { "foo": (42) };
+
+foo = { thisLineWouldBeTooLong:
+    soUseAnotherLine };
+
+//Bad with allign with "align": "value" 
+var obj = {
+    a: value,
+    bcde:  42,
+    fg :   foo()
+};
+
+//Good with allign with "align": "value"
+var obj = {
+    a:    value,
+    bcde: 42,
+
+    fg: foo(),
+    h:  function() {
+        return this.a;
+    },
+    ijkl: 'Non-consecutive lines form a new group'
+};
+
+var obj = { a: "foo", longPropertyName: "bar" };
+
+//Bad with allign with "align": "Colon" 
+var obj = {
+    one:   1,
+    "two": 2,
+    three:  3 
+};
+
+//Good with allign with "align": "Colon"
+var obj = {
+    foobar   : 42,
+    bat      : (2 * 2),
+    "default": fn(),
+
+    fn : function() {},
+    abc: value
+};
+```
+
+[Source](https://eslint.vuejs.org/rules/key-spacing.html#vue-key-spacing)

--- a/src/main/resources/docs/description/vue_match-component-file-name.md
+++ b/src/main/resources/docs/description/vue_match-component-file-name.md
@@ -1,0 +1,35 @@
+Require component name property to match its file name
+
+This rule reports if a component name property does not match its file name.
+
+You can define an array of file extensions this rule should verify for the component's name.
+
+```
+//Bad:
+// file name: src/MyComponent.jsx
+export default {
+  /* ✗ BAD */
+  name: 'MComponent', // note the missing y
+  render() {
+    return <h1>Hello world</h1>
+  }
+}
+
+//Good:
+// file name: src/MyComponent.jsx
+export default {
+  name: 'MyComponent',
+  render() {
+    return <h1>Hello world</h1>
+  }
+}
+
+//Good:
+// file name: src/MyComponent.jsx
+export default {
+  name: 'my-component',
+  render() { return <div /> }
+}
+```
+
+[Source](https://eslint.vuejs.org/rules/match-component-file-name.html#vue-match-component-file-name)

--- a/src/main/resources/docs/description/vue_no-boolean-default.md
+++ b/src/main/resources/docs/description/vue_no-boolean-default.md
@@ -1,0 +1,23 @@
+Disallow boolean defaults
+
+The rule is to enforce the HTML standard of always defaulting boolean attributes to false.
+
+```
+export default {
+  props: {
+  
+    //Bad:
+    foo: {
+      type: Boolean,
+      default: true
+    },
+    
+    //Good:
+    bar: {
+      type: Boolean
+    }
+  }
+}
+```
+
+[Source](https://eslint.vuejs.org/rules/no-boolean-default.html#vue-no-boolean-default)

--- a/src/main/resources/docs/description/vue_no-restricted-syntax.md
+++ b/src/main/resources/docs/description/vue_no-restricted-syntax.md
@@ -1,0 +1,18 @@
+Disallow specified syntax
+
+This rule is the same rule as core no-restricted-syntax rule but it applies to the expressions in `<template>`.
+
+```
+<template>
+  //Bad:
+  <div> {{ foo() }} </div>
+  <div> {{ foo.bar() }} </div>
+  <div> {{ foo().bar }} </div>
+  
+  //Good:
+  <div> {{ foo }} </div>
+  <div> {{ foo.bar }} </div>
+</template>
+```
+
+[Source](https://eslint.vuejs.org/rules/no-restricted-syntax.html#vue-no-restricted-syntax)

--- a/src/main/resources/docs/description/vue_object-curly-spacing.md
+++ b/src/main/resources/docs/description/vue_object-curly-spacing.md
@@ -1,0 +1,14 @@
+Enforce consistent spacing inside braces
+
+This rule is the same rule as core object-curly-spacing rule but it applies to the expressions in `<template>`.
+
+```
+//Bad:
+var obj = {'foo': 'bar'};
+var obj = { 'foo':'bar'};
+ 
+//Good:
+var obj = { 'foo': 'bar' };
+```
+
+[Source](https://eslint.vuejs.org/rules/object-curly-spacing.html#vue-object-curly-spacing)

--- a/src/main/resources/docs/description/vue_require-direct-export.md
+++ b/src/main/resources/docs/description/vue_require-direct-export.md
@@ -1,0 +1,29 @@
+Require the component to be directly exported
+
+This rule aims to require that the component object be directly exported.
+
+```
+//Bad:
+const ComponentA = {
+  name: 'ComponentA',
+  data() {
+    return {
+      state: 1
+    }
+  }
+}
+
+export default ComponentA
+
+//Good:
+export default {
+  name: 'ComponentA',
+  data() {
+    return {
+      state: 1
+    }
+  }
+}
+```
+
+[Source](https://eslint.vuejs.org/rules/require-direct-export.html#vue-require-direct-export)

--- a/src/main/resources/docs/description/vue_space-infix-ops.md
+++ b/src/main/resources/docs/description/vue_space-infix-ops.md
@@ -1,0 +1,17 @@
+Require spacing around infix operators
+
+This rule is the same rule as core space-infix-ops rule but it applies to the expressions in `<template>`.
+
+```
+//Bad:
+a+b
+a+ b
+a +b
+
+//Good:
+a + b
+a       + b
+a ? b : c
+```
+
+[Source](https://eslint.vuejs.org/rules/space-infix-ops.html#vue-space-infix-ops)

--- a/src/main/resources/docs/description/vue_space-unary-ops.md
+++ b/src/main/resources/docs/description/vue_space-unary-ops.md
@@ -1,0 +1,17 @@
+Enforce consistent spacing before or after unary operators
+
+This rule is the same rule as core space-unary-ops rule but it applies to the expressions in `<template>`.
+
+```
+//Bad:
+typeof!foo;
+void{foo:0};
+new[foo][0];
+
+//Good:
+delete foo.bar;
+new Foo;
+void 0;
+```
+
+[Source](https://eslint.vuejs.org/rules/space-unary-ops.html#vue-space-unary-ops)

--- a/src/main/resources/docs/description/vue_v-on-function-call.md
+++ b/src/main/resources/docs/description/vue_v-on-function-call.md
@@ -1,0 +1,19 @@
+Enforce or forbid parentheses after method calls without arguments in `v-on` directives
+
+This rule aims to enforce to bind methods to v-on or call methods on v-on when without arguments.
+
+```
+<template>
+  //Bad:
+  <button v-on:click="closeModal()">
+    Close
+  </button>
+  
+  //Good:
+  <button v-on:click="closeModal">
+    Close
+  </button>
+</template>
+```
+
+[Source](https://eslint.vuejs.org/rules/v-on-function-call.html#vue-v-on-function-call)

--- a/src/main/resources/docs/patterns.json
+++ b/src/main/resources/docs/patterns.json
@@ -3,6 +3,195 @@
   "version": "5.16.0",
   "patterns": [
     {
+      "patternId": "no-assigning-return-values",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "no-unnecessary-waiting",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "assertion-before-screenshot",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "import_no-cycle",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "import_no-named-export",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "import_no-duplicates",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "import_no-useless-path-segments",
+      "level": "Info",
+      "category": "CodeStyle",
+      "parameters": [
+        {
+          "name": "noUselessIndex",
+          "default": false
+        }
+      ]
+    },
+    {
+      "patternId": "import_prefer-inline-snapshots",
+      "level": "Warning",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "vue_array-bracket-spacing",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "vue_arrow-spacing",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "vue_block-spacing",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "vue_brace-style",
+      "level": "Info",
+      "category": "CodeStyle",
+      "parameters": [
+        {
+          "name": "unnamedParam",
+          "default": "1tbs"
+        },
+        {
+          "name": "allowSingleLine",
+          "default": false
+        }
+      ]
+    },
+    {
+      "patternId": "vue_camelcase",
+      "level": "Info",
+      "category": "CodeStyle",
+      "parameters": [
+        {
+          "name": "properties",
+          "default": "always"
+        }
+      ]
+    },
+    {
+      "patternId": "vue_comma-dangle",
+      "level": "Info",
+      "category": "CodeStyle",
+      "parameters": [
+        {
+          "name": "comma-dangle",
+          "default": "never"
+        }
+      ]
+    },
+    {
+      "patternId": "vue_eqeqeq",
+      "level": "Info",
+      "category": "CodeStyle",
+      "parameters": [
+        {
+          "name": "unnamedParam",
+          "default": "smart"
+        }
+      ]
+    },
+    {
+      "patternId": "vue_key-spacing",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "vue_match-component-file-name",
+      "level": "Info",
+      "category": "CodeStyle",
+      "parameters": [
+        {
+          "name": "shouldMatchCase",
+          "default": false
+        },
+        {
+          "name": "extensions",
+          "default": [
+            "jsx"
+          ]
+        }
+      ]
+    },
+    {
+      "patternId": "vue_no-boolean-default",
+      "level": "Info",
+      "category": "CodeStyle",
+      "parameters": [
+        {
+          "name": "unnamedParam",
+          "default": "no-default"
+        }
+      ]
+    },
+    {
+      "patternId": "vue_no-restricted-syntax",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "vue_object-curly-spacing",
+      "level": "Info",
+      "category": "CodeStyle",
+      "parameters": [
+        {
+          "name": "unnamedParam",
+          "default": "never"
+        }
+      ]
+    },
+    {
+      "patternId": "vue_space-infix-ops",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "vue_space-unary-ops",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "vue_v-on-function-call",
+      "level": "Info",
+      "category": "CodeStyle",
+      "parameters": [
+        {
+          "name": "unnamedParam",
+          "default": "never"
+        }
+      ]
+    },
+    {
+      "patternId": "no-jasmin-globals",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "control-has-associated-label",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
       "patternId": "no-useless-catch",
       "level": "Info",
       "category": "CodeStyle"


### PR DESCRIPTION
The following npm packages have been updated with their respective documentation updated to match. 

* npm 5 -> 6
* webpack 3.6.0 -> 4.32.2
* typescript 3.4.1 -> 3.2.5
* eslint-plugin-flowtype 2.35.1 -> 3.9.1
* eslint-plugin-import 2.9.0 -> 2.17.2
* eslint-plugin-jest 21.15.0	-> 22.6.4
* eslint-plugin-jsx-a11y 6.1.2 -> 6.2.1
* eslint-plugin-vue	5.0.0	-> 5.2.2
* eslint-plugin-prettier 3.0.0	-> 3.1.0
* eslint-plugin-react	7.11.1 -> 7.13.0