### PR TITLE
Feature/updated remaining packages

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,7 @@ def installAll(toolVersion: String) =
      |npm install -g eslint-plugin-drupal@0.3.1 &&
      |npm install -g eslint-plugin-lodash-fp@2.1.3 &&
      |npm install -g eslint-plugin-mocha@4.11.0 &&
-     |npm install -g eslint-plugin-chai-expect@1.1.1 &&
+     |npm install -g eslint-plugin-chai-expect@2.0.1 &&
      |npm install -g eslint-plugin-mongodb@0.2.4 &&
      |npm install -g eslint-plugin-no-unsafe-innerhtml@1.0.16 &&
      |npm install -g eslint-plugin-hapi@4.1.0 &&

--- a/build.sbt
+++ b/build.sbt
@@ -98,7 +98,7 @@ def installAll(toolVersion: String) =
      |npm install -g eslint-plugin-lodash@5.1.0 &&
      |npm install -g eslint-plugin-meteor@5.1.1 &&
      |npm install -g eslint-plugin-no-only-tests@2.3.0 &&
-     |npm install -g eslint-plugin-no-unsanitized@3.0.0 &&
+     |npm install -g eslint-plugin-no-unsanitized@3.0.2 &&
      |npm install -g eslint-config-rallycoding@3.2.0 &&
      |npm install -g eslint-config-react-app@3.0.5 &&
      |npm install -g eslint-config-react@1.1.7 &&

--- a/build.sbt
+++ b/build.sbt
@@ -90,7 +90,7 @@ def installAll(toolVersion: String) =
      |npm install -g eslint-config-xo@0.18.2 &&
      |npm install -g eslint-config-xo-react@0.13.0 &&
      |npm install -g eslint-config-xo-space@0.16.0 &&
-     |npm install -g eslint-plugin-angular@3.1.1 &&
+     |npm install -g eslint-plugin-angular@4.0.1 &&
      |npm install -g eslint-plugin-babel@5.2.0 &&
      |npm install -g eslint-plugin-backbone@2.1.1 &&
      |npm install -g eslint-plugin-flowtype@3.9.1 &&

--- a/build.sbt
+++ b/build.sbt
@@ -95,7 +95,7 @@ def installAll(toolVersion: String) =
      |npm install -g eslint-plugin-backbone@2.1.1 &&
      |npm install -g eslint-plugin-flowtype@3.9.1 &&
      |npm install -g eslint-plugin-html@5.0.5 &&
-     |npm install -g eslint-plugin-lodash@2.4.5 &&
+     |npm install -g eslint-plugin-lodash@5.1.0 &&
      |npm install -g eslint-plugin-meteor@4.1.4 &&
      |npm install -g eslint-plugin-no-only-tests@2.0.0 &&
      |npm install -g eslint-plugin-no-unsanitized@3.0.0 &&

--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,7 @@ def installAll(toolVersion: String) =
      |npm install -g eslint-config-simplifield@7.0.1 &&
      |npm install -g eslint-plugin-drupal@0.3.1 &&
      |npm install -g eslint-plugin-lodash-fp@2.1.3 &&
-     |npm install -g eslint-plugin-mocha@4.11.0 &&
+     |npm install -g eslint-plugin-mocha@5.3.0 &&
      |npm install -g eslint-plugin-chai-expect@2.0.1 &&
      |npm install -g eslint-plugin-mongodb@0.2.4 &&
      |npm install -g eslint-plugin-no-unsafe-innerhtml@1.0.16 &&

--- a/build.sbt
+++ b/build.sbt
@@ -102,7 +102,7 @@ def installAll(toolVersion: String) =
      |npm install -g eslint-config-rallycoding@3.2.0 &&
      |npm install -g eslint-config-react-app@3.0.5 &&
      |npm install -g eslint-config-react@1.1.7 &&
-     |npm install -g eslint-plugin-jasmine@2.9.3 &&
+     |npm install -g eslint-plugin-jasmine@2.10.1 &&
      |npm install -g eslint-plugin-sfdx@1.0 &&
      |npm install -g eslint-plugin-redux-saga@0.8.0 &&
      |npm install -g eslint-config-gatsby-standard@1.2.0 &&

--- a/build.sbt
+++ b/build.sbt
@@ -96,7 +96,7 @@ def installAll(toolVersion: String) =
      |npm install -g eslint-plugin-flowtype@3.9.1 &&
      |npm install -g eslint-plugin-html@5.0.5 &&
      |npm install -g eslint-plugin-lodash@5.1.0 &&
-     |npm install -g eslint-plugin-meteor@4.1.4 &&
+     |npm install -g eslint-plugin-meteor@5.1.1 &&
      |npm install -g eslint-plugin-no-only-tests@2.0.0 &&
      |npm install -g eslint-plugin-no-unsanitized@3.0.0 &&
      |npm install -g eslint-config-rallycoding@3.2.0 &&

--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,7 @@ def installAll(toolVersion: String) =
      |npm install -g eslint-config-loopback@8.0.0 &&
      |npm install -g eslint-config-nodesecurity@1.3.1 &&
      |npm install -g eslint-plugin-node@5.1.1 &&
-     |npm install -g eslint-plugin-promise@4.0.1 &&
+     |npm install -g eslint-plugin-promise@4.1.1 &&
      |npm install -g eslint-plugin-standard@3.0.1 &&
      |npm install -g eslint-config-standard@10.2.1 &&
      |npm install -g eslint-config-standard-react@7.0.2 &&

--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,7 @@ def installAll(toolVersion: String) =
      |npm install -g eslint-plugin-no-unsafe-innerhtml@1.0.16 &&
      |npm install -g eslint-plugin-hapi@4.1.0 &&
      |npm install -g eslint-plugin-security@1.4.0 &&
-     |npm install -g eslint-plugin-sorting@0.3.0 &&
+     |npm install -g eslint-plugin-sorting@0.4.1 &&
      |npm install -g eslint-config-xo@0.18.2 &&
      |npm install -g eslint-config-xo-react@0.13.0 &&
      |npm install -g eslint-config-xo-space@0.16.0 &&

--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ def installAll(toolVersion: String) =
      |npm install -g eslint-plugin-import@2.17.3 &&
      |npm install -g eslint-plugin-jsx-a11y@6.2.1 &&
      |npm install -g eslint-plugin-react@7.13.0 &&
-     |npm install -g eslint-plugin-react-native@3.5.0 &&
+     |npm install -g eslint-plugin-react-native@3.7.0 &&
      |npm install -g webpack@4.32.2 &&
      |npm install -g eslint-plugin-jest@22.6.4 &&
      |npm install -g eslint-import-resolver-webpack@0.8.3 &&

--- a/build.sbt
+++ b/build.sbt
@@ -97,7 +97,7 @@ def installAll(toolVersion: String) =
      |npm install -g eslint-plugin-html@5.0.5 &&
      |npm install -g eslint-plugin-lodash@5.1.0 &&
      |npm install -g eslint-plugin-meteor@5.1.1 &&
-     |npm install -g eslint-plugin-no-only-tests@2.0.0 &&
+     |npm install -g eslint-plugin-no-only-tests@2.3.0 &&
      |npm install -g eslint-plugin-no-unsanitized@3.0.0 &&
      |npm install -g eslint-config-rallycoding@3.2.0 &&
      |npm install -g eslint-config-react-app@3.0.5 &&

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ def installAll(toolVersion: String) =
      |npm install -g npm@6 &&
      |npm install -g eslint@$toolVersion &&
      |npm install -g babel-eslint@10.0.1 &&
-     |npm install -g eslint-plugin-import@2.17.2 &&
+     |npm install -g eslint-plugin-import@2.17.3 &&
      |npm install -g eslint-plugin-jsx-a11y@6.2.1 &&
      |npm install -g eslint-plugin-react@7.13.0 &&
      |npm install -g eslint-plugin-react-native@3.5.0 &&

--- a/build.sbt
+++ b/build.sbt
@@ -104,7 +104,7 @@ def installAll(toolVersion: String) =
      |npm install -g eslint-config-react@1.1.7 &&
      |npm install -g eslint-plugin-jasmine@2.10.1 &&
      |npm install -g eslint-plugin-sfdx@1.0 &&
-     |npm install -g eslint-plugin-redux-saga@0.8.0 &&
+     |npm install -g eslint-plugin-redux-saga@1.0.0 &&
      |npm install -g eslint-config-gatsby-standard@1.2.0 &&
      |npm install -g eslint-plugin-react-intl@1.1.2 &&
      |npm install -g eslint-plugin-json@1.4.0 &&

--- a/build.sbt
+++ b/build.sbt
@@ -94,7 +94,7 @@ def installAll(toolVersion: String) =
      |npm install -g eslint-plugin-babel@5.3.0 &&
      |npm install -g eslint-plugin-backbone@2.1.1 &&
      |npm install -g eslint-plugin-flowtype@3.9.1 &&
-     |npm install -g eslint-plugin-html@3.2.2 &&
+     |npm install -g eslint-plugin-html@5.0.5 &&
      |npm install -g eslint-plugin-lodash@2.4.5 &&
      |npm install -g eslint-plugin-meteor@4.1.4 &&
      |npm install -g eslint-plugin-no-only-tests@2.0.0 &&

--- a/build.sbt
+++ b/build.sbt
@@ -107,7 +107,7 @@ def installAll(toolVersion: String) =
      |npm install -g eslint-plugin-redux-saga@0.8.0 &&
      |npm install -g eslint-config-gatsby-standard@1.2.0 &&
      |npm install -g eslint-plugin-react-intl@1.1.2 &&
-     |npm install -g eslint-plugin-json@1.2.1 &&
+     |npm install -g eslint-plugin-json@1.4.0 &&
      |npm install -g eslint-plugin-cypress@2.2.1 &&
      |npm install -g eslint-plugin-chai-friendly@0.4.1 &&
      |npm install -g @prodigy/eslint-config-prodigy &&

--- a/build.sbt
+++ b/build.sbt
@@ -49,35 +49,35 @@ def installAll(toolVersion: String) =
      |npm install -g eslint-plugin-react-native@3.7.0 &&
      |npm install -g webpack@4.32.2 &&
      |npm install -g eslint-plugin-jest@22.6.4 &&
-     |npm install -g eslint-import-resolver-webpack@0.8.3 &&
-     |npm install -g eslint-import-resolver-node@0.3.1 &&
+     |npm install -g eslint-import-resolver-webpack@0.11.1 &&
+     |npm install -g eslint-import-resolver-node@0.3.2 &&
      |npm install -g eslint-config-airbnb-base@13.1.0 &&
      |npm install -g eslint-config-airbnb@17.1.0 &&
      |npm install -g eslint-config-angular@0.5.0 &&
      |npm install -g eslint-config-apiconnect@2.0.1 &&
-     |npm install -g eslint-config-drupal@3.0.0 &&
+     |npm install -g eslint-config-drupal@4.0.1 &&
      |npm install -g eslint-config-es5@0.5.0 &&
      |npm install -g eslint-config-es6@1.10.3 &&
-     |npm install -g eslint-config-loopback@8.0.0 &&
+     |npm install -g eslint-config-loopback@13.1.0 &&
      |npm install -g eslint-config-nodesecurity@1.3.1 &&
      |npm install -g eslint-plugin-node@5.1.1 &&
      |npm install -g eslint-plugin-promise@4.1.1 &&
      |npm install -g eslint-plugin-standard@4.0.0 &&
-     |npm install -g eslint-config-standard@10.2.1 &&
+     |npm install -g eslint-config-standard@12.0.0 &&
      |npm install -g eslint-config-standard-react@7.0.2 &&
      |npm install -g eslint-config-strongloop@2.1.0 &&
      |npm install -g eslint-plugin-vue@5.2.2 &&
      |npm install -g eslint-config-vue@2.0.2 &&
-     |npm install -g eslint-config-winedirect@1.0.0 &&
+     |npm install -g eslint-config-winedirect@1.1.0 &&
      |npm install -g lint-staged@8.1.7 &&
-     |npm install -g eslint-config-dbk@2.0.0 &&
-     |npm install -g eslint-config-google@0.9.1 &&
+     |npm install -g eslint-config-dbk@3.3.4 &&
+     |npm install -g eslint-config-google@0.13.0 &&
      |npm install -g prettier@1.17.1 &&
      |npm install -g eslint-plugin-prettier@3.1.0 &&
      |npm install -g eslint-config-prettier@4.3.0 &&
      |npm install -g eslint-config-signavio-test@2.0.0 &&
      |npm install -g eslint-config-signavio@3.2.0 &&
-     |npm install -g eslint-config-simplifield@7.0.1 &&
+     |npm install -g eslint-config-simplifield@9.0.0 &&
      |npm install -g eslint-plugin-drupal@0.3.1 &&
      |npm install -g eslint-plugin-lodash-fp@2.1.3 &&
      |npm install -g eslint-plugin-mocha@5.3.0 &&
@@ -87,9 +87,9 @@ def installAll(toolVersion: String) =
      |npm install -g eslint-plugin-hapi@4.1.0 &&
      |npm install -g eslint-plugin-security@1.4.0 &&
      |npm install -g eslint-plugin-sorting@0.4.1 &&
-     |npm install -g eslint-config-xo@0.18.2 &&
-     |npm install -g eslint-config-xo-react@0.13.0 &&
-     |npm install -g eslint-config-xo-space@0.16.0 &&
+     |npm install -g eslint-config-xo@0.26.0 &&
+     |npm install -g eslint-config-xo-react@0.19.0 &&
+     |npm install -g eslint-config-xo-space@0.21.0 &&
      |npm install -g eslint-plugin-angular@4.0.1 &&
      |npm install -g eslint-plugin-babel@5.3.0 &&
      |npm install -g eslint-plugin-backbone@2.1.1 &&
@@ -100,17 +100,17 @@ def installAll(toolVersion: String) =
      |npm install -g eslint-plugin-no-only-tests@2.3.0 &&
      |npm install -g eslint-plugin-no-unsanitized@3.0.2 &&
      |npm install -g eslint-config-rallycoding@3.2.0 &&
-     |npm install -g eslint-config-react-app@3.0.5 &&
+     |npm install -g eslint-config-react-app@4.0.1 &&
      |npm install -g eslint-config-react@1.1.7 &&
      |npm install -g eslint-plugin-jasmine@2.10.1 &&
      |npm install -g eslint-plugin-sfdx@1.0 &&
      |npm install -g eslint-plugin-redux-saga@1.0.0 &&
-     |npm install -g eslint-config-gatsby-standard@1.2.0 &&
+     |npm install -g eslint-config-gatsby-standard@2.2.0 &&
      |npm install -g eslint-plugin-react-intl@1.1.2 &&
      |npm install -g eslint-plugin-json@1.4.0 &&
      |npm install -g eslint-plugin-cypress@2.2.1 &&
      |npm install -g eslint-plugin-chai-friendly@0.4.1 &&
-     |npm install -g @prodigy/eslint-config-prodigy &&
+     |npm install -g @prodigy/eslint-config-prodigy@0.0.7 &&
      |npm install -g eslint-plugin-ember-suave@1.0.0 &&
      |npm install -g typescript@3.4.5 &&
      |npm install -g @typescript-eslint/eslint-plugin@1.9.0 &&

--- a/build.sbt
+++ b/build.sbt
@@ -40,82 +40,82 @@ toolVersion := {
 def installAll(toolVersion: String) =
   s"""apk update &&
      |apk add bash curl nodejs-npm &&
-     |npm install -g npm@6 &&
-     |npm install -g eslint@$toolVersion &&
-     |npm install -g babel-eslint@10.0.1 &&
-     |npm install -g eslint-plugin-import@2.17.3 &&
-     |npm install -g eslint-plugin-jsx-a11y@6.2.1 &&
-     |npm install -g eslint-plugin-react@7.13.0 &&
-     |npm install -g eslint-plugin-react-native@3.7.0 &&
+     |npm install -g @prodigy/eslint-config-prodigy@0.0.7 &&
+     |npm install -g @typescript-eslint/eslint-plugin@1.9.0 &&
+     |npm install -g @typescript-eslint/parser@1.9.0 &&
+     |npm install -g lint-staged@8.1.7 &&
+     |npm install -g npm@6.9.0 &&
+     |npm install -g prettier@1.17.1 &&
+     |npm install -g typescript@3.4.1 &&
      |npm install -g webpack@4.32.2 &&
-     |npm install -g eslint-plugin-jest@22.6.4 &&
-     |npm install -g eslint-import-resolver-webpack@0.11.1 &&
-     |npm install -g eslint-import-resolver-node@0.3.2 &&
-     |npm install -g eslint-config-airbnb-base@13.1.0 &&
+     |npm install -g babel-eslint@10.0.1 &&
+     |npm install -g eslint@$toolVersion &&
      |npm install -g eslint-config-airbnb@17.1.0 &&
+     |npm install -g eslint-config-airbnb-base@13.1.0 &&
      |npm install -g eslint-config-angular@0.5.0 &&
      |npm install -g eslint-config-apiconnect@2.0.1 &&
+     |npm install -g eslint-config-dbk@3.3.4 &&
      |npm install -g eslint-config-drupal@4.0.1 &&
      |npm install -g eslint-config-es5@0.5.0 &&
      |npm install -g eslint-config-es6@1.10.3 &&
+     |npm install -g eslint-config-gatsby-standard@2.2.0 &&
+     |npm install -g eslint-config-google@0.13.0 &&
      |npm install -g eslint-config-loopback@13.1.0 &&
      |npm install -g eslint-config-nodesecurity@1.3.1 &&
-     |npm install -g eslint-plugin-node@5.1.1 &&
-     |npm install -g eslint-plugin-promise@4.1.1 &&
-     |npm install -g eslint-plugin-standard@4.0.0 &&
+     |npm install -g eslint-config-prettier@4.3.0 &&
+     |npm install -g eslint-config-rallycoding@3.2.0 &&
+     |npm install -g eslint-config-react@1.1.7 &&
+     |npm install -g eslint-config-react-app@4.0.1 &&
+     |npm install -g eslint-config-signavio@3.2.0 &&
+     |npm install -g eslint-config-signavio-test@2.0.0 &&
+     |npm install -g eslint-config-simplifield@9.0.0 &&
      |npm install -g eslint-config-standard@12.0.0 &&
      |npm install -g eslint-config-standard-react@7.0.2 &&
      |npm install -g eslint-config-strongloop@2.1.0 &&
-     |npm install -g eslint-plugin-vue@5.2.2 &&
      |npm install -g eslint-config-vue@2.0.2 &&
      |npm install -g eslint-config-winedirect@1.1.0 &&
-     |npm install -g lint-staged@8.1.7 &&
-     |npm install -g eslint-config-dbk@3.3.4 &&
-     |npm install -g eslint-config-google@0.13.0 &&
-     |npm install -g prettier@1.17.1 &&
-     |npm install -g eslint-plugin-prettier@3.1.0 &&
-     |npm install -g eslint-config-prettier@4.3.0 &&
-     |npm install -g eslint-config-signavio-test@2.0.0 &&
-     |npm install -g eslint-config-signavio@3.2.0 &&
-     |npm install -g eslint-config-simplifield@9.0.0 &&
-     |npm install -g eslint-plugin-drupal@0.3.1 &&
-     |npm install -g eslint-plugin-lodash-fp@2.1.3 &&
-     |npm install -g eslint-plugin-mocha@5.3.0 &&
-     |npm install -g eslint-plugin-chai-expect@2.0.1 &&
-     |npm install -g eslint-plugin-mongodb@0.2.4 &&
-     |npm install -g eslint-plugin-no-unsafe-innerhtml@1.0.16 &&
-     |npm install -g eslint-plugin-hapi@4.1.0 &&
-     |npm install -g eslint-plugin-security@1.4.0 &&
-     |npm install -g eslint-plugin-sorting@0.4.1 &&
      |npm install -g eslint-config-xo@0.26.0 &&
      |npm install -g eslint-config-xo-react@0.19.0 &&
      |npm install -g eslint-config-xo-space@0.21.0 &&
+     |npm install -g eslint-import-resolver-node@0.3.2 &&
+     |npm install -g eslint-import-resolver-webpack@0.11.1 &&
      |npm install -g eslint-plugin-angular@4.0.1 &&
      |npm install -g eslint-plugin-babel@5.3.0 &&
      |npm install -g eslint-plugin-backbone@2.1.1 &&
-     |npm install -g eslint-plugin-flowtype@3.9.1 &&
-     |npm install -g eslint-plugin-html@5.0.5 &&
-     |npm install -g eslint-plugin-lodash@5.1.0 &&
-     |npm install -g eslint-plugin-meteor@5.1.1 &&
-     |npm install -g eslint-plugin-no-only-tests@2.3.0 &&
-     |npm install -g eslint-plugin-no-unsanitized@3.0.2 &&
-     |npm install -g eslint-config-rallycoding@3.2.0 &&
-     |npm install -g eslint-config-react-app@4.0.1 &&
-     |npm install -g eslint-config-react@1.1.7 &&
-     |npm install -g eslint-plugin-jasmine@2.10.1 &&
-     |npm install -g eslint-plugin-sfdx@1.0 &&
-     |npm install -g eslint-plugin-redux-saga@1.0.0 &&
-     |npm install -g eslint-config-gatsby-standard@2.2.0 &&
-     |npm install -g eslint-plugin-react-intl@1.1.2 &&
-     |npm install -g eslint-plugin-json@1.4.0 &&
-     |npm install -g eslint-plugin-cypress@2.2.1 &&
+     |npm install -g eslint-plugin-chai-expect@2.0.1 &&
      |npm install -g eslint-plugin-chai-friendly@0.4.1 &&
-     |npm install -g @prodigy/eslint-config-prodigy@0.0.7 &&
+     |npm install -g eslint-plugin-cypress@2.2.1 &&
+     |npm install -g eslint-plugin-drupal@0.3.1 &&
      |npm install -g eslint-plugin-ember-suave@1.0.0 &&
-     |npm install -g typescript@3.4.5 &&
-     |npm install -g @typescript-eslint/eslint-plugin@1.9.0 &&
-     |npm install -g @typescript-eslint/parser@1.9.0 &&
+     |npm install -g eslint-plugin-flowtype@3.9.1 &&
+     |npm install -g eslint-plugin-hapi@4.1.0 &&
+     |npm install -g eslint-plugin-html@5.0.5 &&
+     |npm install -g eslint-plugin-import@2.17.3 &&
+     |npm install -g eslint-plugin-jasmine@2.10.1 &&
+     |npm install -g eslint-plugin-jest@22.6.4 &&
+     |npm install -g eslint-plugin-json@1.4.0 &&
+     |npm install -g eslint-plugin-jsx-a11y@6.2.1 &&
+     |npm install -g eslint-plugin-lodash@5.1.0 &&
+     |npm install -g eslint-plugin-lodash-fp@2.1.3 &&
+     |npm install -g eslint-plugin-meteor@5.1.1 &&
+     |npm install -g eslint-plugin-mocha@5.3.0 &&
+     |npm install -g eslint-plugin-mongodb@0.2.4 &&
+     |npm install -g eslint-plugin-no-only-tests@2.3.0 &&
+     |npm install -g eslint-plugin-no-unsafe-innerhtml@1.0.16 &&
+     |npm install -g eslint-plugin-no-unsanitized@3.0.2 &&
+     |npm install -g eslint-plugin-node@5.1.1 &&
+     |npm install -g eslint-plugin-prettier@3.1.0 &&
+     |npm install -g eslint-plugin-promise@4.1.1 &&
+     |npm install -g eslint-plugin-react@7.13.0 &&
+     |npm install -g eslint-plugin-react-intl@1.1.2 &&
+     |npm install -g eslint-plugin-react-native@3.7.0 &&
+     |npm install -g eslint-plugin-redux-saga@1.0.0 &&
      |npm install -g eslint-plugin-relay@1.3.1 &&
+     |npm install -g eslint-plugin-security@1.4.0 &&
+     |npm install -g eslint-plugin-sfdx@1.0 &&
+     |npm install -g eslint-plugin-sorting@0.4.1 &&
+     |npm install -g eslint-plugin-standard@4.0.0 &&
+     |npm install -g eslint-plugin-vue@5.2.2 &&
      |rm -rf /tmp/* &&
      |rm -rf /var/cache/apk/*""".stripMargin
     .replaceAll(System.lineSeparator(), " ")

--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ def installAll(toolVersion: String) =
      |npm install -g eslint-config-nodesecurity@1.3.1 &&
      |npm install -g eslint-plugin-node@5.1.1 &&
      |npm install -g eslint-plugin-promise@4.1.1 &&
-     |npm install -g eslint-plugin-standard@3.0.1 &&
+     |npm install -g eslint-plugin-standard@4.0.0 &&
      |npm install -g eslint-config-standard@10.2.1 &&
      |npm install -g eslint-config-standard-react@7.0.2 &&
      |npm install -g eslint-config-strongloop@2.1.0 &&

--- a/build.sbt
+++ b/build.sbt
@@ -91,7 +91,7 @@ def installAll(toolVersion: String) =
      |npm install -g eslint-config-xo-react@0.13.0 &&
      |npm install -g eslint-config-xo-space@0.16.0 &&
      |npm install -g eslint-plugin-angular@4.0.1 &&
-     |npm install -g eslint-plugin-babel@5.2.0 &&
+     |npm install -g eslint-plugin-babel@5.3.0 &&
      |npm install -g eslint-plugin-backbone@2.1.1 &&
      |npm install -g eslint-plugin-flowtype@3.9.1 &&
      |npm install -g eslint-plugin-html@3.2.2 &&

--- a/src/main/resources/docs/description/angular_angularelement.md
+++ b/src/main/resources/docs/description/angular_angularelement.md
@@ -1,0 +1,13 @@
+Use angular.element instead of $ or jQuery
+
+The angular.element method should be used instead of the $ or jQuery object (if you are using jQuery of course). If the jQuery library is imported, angular.element will be a wrapper around the jQuery object.
+
+```
+//Bad:
+$('.some-class'); // error: You should use angular.element instead of the jQuery $ object
+
+//Good:
+jQuery('.another-class'); // error: You should use angular.element instead of the jQuery $ object
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/angularelement.md)

--- a/src/main/resources/docs/description/angular_avoid-scope-typos.md
+++ b/src/main/resources/docs/description/angular_avoid-scope-typos.md
@@ -1,0 +1,21 @@
+Avoid mistakes when naming methods defined on the scope object
+
+```
+//Bad:
+$scope.apply.forEach(function (watcher) {
+    // ...
+}); // error: The apply method should be replaced by $apply, or you should rename it in order to avoid confusions
+
+//Bad:
+$rootScope.apply.forEach(function (watcher) {
+    // ...
+}); // error: The apply method should be replaced by $apply, or you should rename it in order to avoid confusions
+
+//Good:
+$scope.$apply();
+
+//Good:
+$rootScope.$apply();
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/avoid-scope-typos.md)

--- a/src/main/resources/docs/description/angular_component-limit.md
+++ b/src/main/resources/docs/description/angular_component-limit.md
@@ -1,0 +1,21 @@
+Limit the number of angular components per file
+
+The number of AngularJS components in one file should be limited. The default limit is one.
+
+The acceptable number of components. (Default: 1)
+
+```
+//Bad:
+angular.module('myModule').controller('ControllerOne', function() {
+    // ...
+}).directive('directiveTwo', function() {
+    // ...
+}); // error: There may be at most 1 AngularJS component per file, but found 2
+
+//Good:
+angular.module('myModule').controller('SomeController', function() {
+    // ...
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/component-limit.md)

--- a/src/main/resources/docs/description/angular_component-name.md
+++ b/src/main/resources/docs/description/angular_component-name.md
@@ -1,0 +1,17 @@
+Require and specify a prefix for all component names
+
+All your components should have a name starting with the parameter you can define in your config object. The second parameter can be a Regexp wrapped in quotes. You can not prefix your components by "ng" (reserved keyword for AngularJS components) ("component-name": [2, "ng"])
+
+```
+//Bad:
+angular.module('myModule').component('navigation', {
+    // ...
+}); // error: The navigation component should follow this pattern: /^ui/
+
+//Good:
+angular.module('myModule').component('prefixTabs', {
+    // ...
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/component-name.md)

--- a/src/main/resources/docs/description/angular_constant-name.md
+++ b/src/main/resources/docs/description/angular_constant-name.md
@@ -1,0 +1,17 @@
+Require and specify a prefix for all constant names
+
+All your constants should have a name starting with the parameter you can define in your config object. The second parameter can be a Regexp wrapped in quotes. You can not prefix your constants by "$" (reserved keyword for AngularJS services) ("constant-name": [2, "ng"]) *
+
+```
+//Bad:
+angular.module('myModule').constant('otherConstant', function () {
+    // ...
+}); // error: The otherConstant constant should follow this pattern: /^xyz/
+
+//Good:
+angular.module('myModule').constant('prefixConstant', function () {
+    // ...
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/constant-name.md)

--- a/src/main/resources/docs/description/angular_controller-as-route.md
+++ b/src/main/resources/docs/description/angular_controller-as-route.md
@@ -1,0 +1,18 @@
+Require the use of controllerAs in routes or states
+
+You should use Angular's controllerAs syntax when defining routes or states.
+
+```
+//Bad:
+$routeProvider.when('/myroute', {
+    controller: 'MyController'
+}) // error: Route "/myroute" should use controllerAs syntax
+
+//Good:
+$routeProvider.when('/myroute', {
+    controller: 'MyController',
+    controllerAs: 'vm'
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/controller-as-route.md)

--- a/src/main/resources/docs/description/angular_controller-as-vm.md
+++ b/src/main/resources/docs/description/angular_controller-as-vm.md
@@ -1,0 +1,21 @@
+Require and specify a capture variable for this in controllers
+
+You should use a capture variable for 'this' when using the controllerAs syntax. The second parameter specifies the capture variable you want to use in your application. The third parameter can be a Regexp for identifying controller functions (when using something like Browserify)
+
+The name that should be used for the view model.
+
+```
+//Bad:
+// invalid
+angular.module('test').controller('TestController', function() {
+    this.test = 'test';
+}); // error: You should not use "this" directly. Instead, assign it to a variable called "vm"
+
+//Good:
+angular.module('test').controller('TestController', function() {
+    var vm = this;
+    vm.test = 'test';
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/controller-as-vm.md)

--- a/src/main/resources/docs/description/angular_controller-as.md
+++ b/src/main/resources/docs/description/angular_controller-as.md
@@ -1,0 +1,25 @@
+Disallow assignments to $scope in controllers
+
+You should not set properties on $scope in controllers. Use controllerAs syntax and add data to 'this'. The second parameter can be a Regexp for identifying controller functions (when using something like Browserify)
+
+```
+//Bad:
+angular.module("myModule").controller("SomeController", function($scope) {
+    $scope.value = 42;
+}); // error: You should not set properties on $scope in controllers. Use controllerAs syntax and add data to "this"
+
+//Good:
+angular.module("myModule").controller("SomeController", function($scope) {
+    // this for values
+    this.value = 42;
+
+    // $scope is fine for watchers
+    $scope.$watch(angular.bind(this, function () {
+        return this.value
+    }), function () {
+        // ...
+    });
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/controller-as.md)

--- a/src/main/resources/docs/description/angular_controller-name.md
+++ b/src/main/resources/docs/description/angular_controller-name.md
@@ -1,0 +1,17 @@
+Require and specify a prefix for all controller names
+
+All your controllers should have a name starting with the parameter you can define in your config object. The second parameter can be a Regexp wrapped in quotes. ("controller-name": [2, "ng"])
+
+```
+//Bad:
+angular.module('myModule').controller('MyCtrl', function () {
+    // ...
+}); // error: The MyCtrl controller should follow this pattern: /^[A-Z][a-zA-Z0-9]*Controller$/
+
+//Good:
+angular.module('myModule').controller('MyController', function () {
+   // ...
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/controller-name.md)

--- a/src/main/resources/docs/description/angular_deferred.md
+++ b/src/main/resources/docs/description/angular_deferred.md
@@ -1,0 +1,16 @@
+Use $q(function(resolve, reject){}) instead of $q.deferred
+
+When you want to create a new promise, you should not use the $q.deferred anymore. Prefer the new syntax : $q(function(resolve, reject){})
+
+```
+//Bad:
+// invalid
+var deferred = $q.defer(); // error: You should not create a new promise with this syntax. Use the $q(function(resolve, reject) {}) syntax.
+
+//Good:
+$q(function() {
+    // ...
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/deferred.md)

--- a/src/main/resources/docs/description/angular_definedundefined.md
+++ b/src/main/resources/docs/description/angular_definedundefined.md
@@ -1,0 +1,13 @@
+Use angular.isDefined and angular.isUndefined instead of other undefined checks
+
+You should use the angular.isUndefined or angular.isDefined methods instead of using the keyword undefined. We also check the use of !angular.isUndefined and !angular.isDefined (should prefer the reverse function)
+
+```
+//Bad:
+value === undefined // error: You should not use directly the "undefined" keyword. Prefer angular.isUndefined or angular.isDefined
+
+//Good:
+angular.isUndefined(value)
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/definedundefined.md)

--- a/src/main/resources/docs/description/angular_di-order.md
+++ b/src/main/resources/docs/description/angular_di-order.md
@@ -1,0 +1,17 @@
+Require DI parameters to be sorted alphabetically
+
+Injected dependencies should be sorted alphabetically. If the second parameter is set to false, values which start and end with an underscore those underscores are stripped. This means for example that _$httpBackend_ goes before _$http_.
+
+```
+//Bad:
+angular.module('myModule').factory('myService', function($q, $http) {
+    // ...
+}); // error: Injected values should be sorted alphabetically
+
+//Good:
+angular.module('myModule').factory('myService', function($http, $location, $q, myService, someService) {
+    // ...
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/di-order.md)

--- a/src/main/resources/docs/description/angular_di-unused.md
+++ b/src/main/resources/docs/description/angular_di-unused.md
@@ -1,0 +1,19 @@
+Disallow unused DI parameters
+
+Unused dependencies should not be injected.
+
+```
+//Bad:
+angular.module('myModule').factory('myService', function ($http, $q, $log) {
+    $http.get('/api/someData').then(function (response) {
+        $log.log(response.data);
+    });
+}); // error: Unused injected value $q
+
+//Good:
+angular.module('myModule').factory('myService', function ($log, anotherService) {
+    $log.log(anotherService.getSomeData());
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/di-unused.md)

--- a/src/main/resources/docs/description/angular_di.md
+++ b/src/main/resources/docs/description/angular_di.md
@@ -1,0 +1,17 @@
+Require a consistent DI syntax
+
+All your DI should use the same syntax : the Array, function, or $inject syntaxes ("di": [2, "array, function, or $inject"])
+
+```
+//Bad:
+angular.module('myModule').factory('myService', ['$http', '$log', 'anotherService', function ($http, $log, anotherService) {
+    // ...
+}]); // error: You should use the function syntax for DI
+
+//Good:
+angular.module('myModule').factory('myService', function ($http, $log, anotherService) {
+   // ...
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/di.md)

--- a/src/main/resources/docs/description/angular_directive-name.md
+++ b/src/main/resources/docs/description/angular_directive-name.md
@@ -1,0 +1,17 @@
+Require and specify a prefix for all directive names
+
+All your directives should have a name starting with the parameter you can define in your config object. The second parameter can be a Regexp wrapped in quotes. You can not prefix your directives by "ng" (reserved keyword for AngularJS directives) ("directive-name": [2, "ng"])
+
+```
+//Bad:
+angular.module('myModule').directive('navigation', function () {
+    // ...
+}); // error: The navigation directive should follow this pattern: /^ui/
+
+//Good:
+angular.module('myModule').directive('prefixTabs', function () {
+    // ...
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/directive-name.md)

--- a/src/main/resources/docs/description/angular_directive-restrict.md
+++ b/src/main/resources/docs/description/angular_directive-restrict.md
@@ -1,0 +1,20 @@
+Disallow any other directive restrict than 'A' or 'E'
+
+```
+//Bad:
+angular.module('myModule').directive('helloWorld', function () {
+    return {
+        template: '<h2>Hello World!</h2>'
+    };
+}); // error: Missing directive restriction
+
+//Good:
+angular.module('myModule').directive('helloWorld', function () {
+    return {
+        template: '<h2>Hello World!</h2>',
+        restrict: 'A' // also allowed: A, E, AE, EA
+    };
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/directive-restrict.md)

--- a/src/main/resources/docs/description/angular_document-service.md
+++ b/src/main/resources/docs/description/angular_document-service.md
@@ -1,0 +1,13 @@
+Use $document instead of document
+
+Instead of the default document object, you should prefer the AngularJS wrapper service $document.
+
+```
+//Bad:
+document.title // error: You should use the $document service instead of the default document object
+
+//Good:
+$document[0].title = ""
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/document-service.md)

--- a/src/main/resources/docs/description/angular_dumb-inject.md
+++ b/src/main/resources/docs/description/angular_dumb-inject.md
@@ -1,0 +1,36 @@
+Unit test inject functions should only consist of assignments from injected values to describe block variables
+
+Inject functions in unittests should only contain a sorted mapping of injected values to values in the describe block
+ with matching names. This way the dependency injection setup is separated from the other setup logic, improving readability of the test.
+
+```
+//Bad:
+describe(function() {
+    var $httpBackend;
+    var $rootScope;
+
+    beforeEach(inject(function(_$httpBackend_, _$rootScope_) {
+        $httpBackend = _$httpBackend_;
+        $rootScope = _$rootScope_;
+
+        $httpBackend.whenGET('/data').respond([]);
+    }));
+}); // error: inject functions may only consist of assignments in the form myService = _myService_
+
+//Good:
+describe(function() {
+    var $httpBackend;
+    var $rootScope;
+
+    beforeEach(inject(function(_$httpBackend_, _$rootScope_) {
+        $httpBackend = _$httpBackend_;
+        $rootScope = _$rootScope_;
+    }));
+
+    beforeEach(function() {
+        $httpBackend.whenGET('/data').respond([]);
+    });
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/dumb-inject.md)

--- a/src/main/resources/docs/description/angular_empty-controller.md
+++ b/src/main/resources/docs/description/angular_empty-controller.md
@@ -1,0 +1,16 @@
+Disallow empty controllers
+
+If you have one empty controller, maybe you have linked it in your Router configuration or in one of your views. You can remove this declaration because this controller is useless
+
+```
+//Bad:
+angular.module('myModule').controller('EmptyController', function () {
+}); // error: The EmptyController controller is useless because empty. You can remove it from your Router configuration or in one of your view
+
+//Good:
+angular.module('myModule').controller('MyController', function ($log) {
+    $log.log('Hello World!');
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/empty-controller.md)

--- a/src/main/resources/docs/description/angular_factory-name.md
+++ b/src/main/resources/docs/description/angular_factory-name.md
@@ -1,0 +1,17 @@
+Require and specify a prefix for all factory names
+
+All your factorys should have a name starting with the parameter you can define in your config object. The second parameter can be a Regexp wrapped in quotes. You can not prefix your factorys by "$" (reserved keyword for AngularJS services) ("factory-name": [2, "ng"])
+
+```
+//Bad:
+angular.module('myModule').factory('otherFactory', function () {
+    // ...
+}); // error: The otherFactory factory should follow this pattern: /^xyz/
+
+//Good:
+angular.module('myModule').factory('prefixFactory', function () {
+    // ...
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/factory-name.md)

--- a/src/main/resources/docs/description/angular_file-name.md
+++ b/src/main/resources/docs/description/angular_file-name.md
@@ -1,0 +1,18 @@
+Require and specify a consistent component name pattern
+
+All your file names should match the angular component name. The second parameter can be a config object [2, {nameStyle: 'dash', typeSeparator: 'dot', ignoreTypeSuffix: true, ignorePrefix: 'ui'}] to match 'avenger-profile.directive.js' or 'avanger-api.service.js'. Possible values for 'typeSeparator' and 'nameStyle' are 'dot', 'dash' and 'underscore'. The options 'ignoreTypeSuffix' ignores camel cased suffixes like 'someController' or 'myService' and 'ignorePrefix' ignores namespace prefixes like 'ui'. It's possible to specify a regexp for ignorePrefix. Example RegExp: "/^ui./".
+
+The naming scheme is <componentName><typeSeparator><componentType>.js
+
+The componentType for all service types (service, factory, provider, value) is 'service'. Since 1.5.0 it is possible to configure custom mappings for the componentType: {typeSeparator: 'dot', componentTypeMappings: {factory: 'factory', provider: 'provider'}.
+
+```
+//Bad:
+app.filter('usefulFilter', function() {}); // error: Filename must be "usefulFilter.js"
+
+//Good:
+//valid with filename: myModule.js
+angular.module('myModule', []);
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/file-name.md)

--- a/src/main/resources/docs/description/angular_filter-name.md
+++ b/src/main/resources/docs/description/angular_filter-name.md
@@ -1,0 +1,17 @@
+Require and specify a prefix for all filter names
+
+All your filters should have a name starting with the parameter you can define in your config object. The second parameter can be a Regexp wrapped in quotes. ("filter-name": [2, "ng"])
+
+```
+//Bad:
+angular.module('myModule').filter('otherFilter', function () {
+    // ...
+}); // error: The otherFilter filter should follow this pattern: /^xyz/
+
+//Good:
+angular.module('myModule').filter('prefixFilter', function () {
+    // ...
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/filter-name.md)

--- a/src/main/resources/docs/description/angular_foreach.md
+++ b/src/main/resources/docs/description/angular_foreach.md
@@ -1,0 +1,17 @@
+Use angular.forEach instead of native Array.prototype.forEach
+
+You should use the angular.forEach method instead of the default JavaScript implementation [].forEach.
+
+```
+//Bad:
+someArray.forEach(function (element) {
+    // ...
+}); // error: You should use the angular.forEach method
+
+//Good:
+angular.forEach(someArray, function (element) {
+    // ...
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/foreach.md)

--- a/src/main/resources/docs/description/angular_function-type.md
+++ b/src/main/resources/docs/description/angular_function-type.md
@@ -1,0 +1,18 @@
+Require and specify a consistent function style for components
+
+Anonymous or named functions inside AngularJS components. The first parameter sets which type of function is required and can be 'named' or 'anonymous'. The second parameter is an optional list of angular object names.
+
+```
+//Bad:
+angular.module('myModule').factory('myService', myServiceFn);
+function myServiceFn() {
+    // ...
+} // error: Use anonymous functions instead of named function
+
+//Good:
+angular.module('myModule').factory('myService', function () {
+    // ...
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/function-type.md)

--- a/src/main/resources/docs/description/angular_interval-service.md
+++ b/src/main/resources/docs/description/angular_interval-service.md
@@ -1,0 +1,18 @@
+Use $interval instead of setInterval
+
+Instead of the default setInterval function, you should use the AngularJS wrapper service $interval
+
+```
+//Bad:
+setInterval(function() {
+    // ...
+}, 1000) // error: You should use the $interval service instead of the default window.setInterval method
+
+//Good:
+$interval(function() {
+    // ...
+}, 1000)
+
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/interval-service.md)

--- a/src/main/resources/docs/description/angular_json-functions.md
+++ b/src/main/resources/docs/description/angular_json-functions.md
@@ -1,0 +1,17 @@
+Enforce use ofangular.fromJson and 'angular.toJson'
+
+You should use angular.fromJson or angular.toJson instead of JSON.parse and JSON.stringify
+
+```
+//Bad:
+JSON.stringify({
+    // ...
+}); // error: You should use the angular.toJson method instead of JSON.stringify
+
+//Good:
+angular.toJson({
+    // ...
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/json-functions.md)

--- a/src/main/resources/docs/description/angular_log.md
+++ b/src/main/resources/docs/description/angular_log.md
@@ -1,0 +1,13 @@
+Use the $log service instead of the console methods
+
+You should use $log service instead of console for the methods 'log', 'debug', 'error', 'info', 'warn'
+
+```
+//Bad:
+console.log('Hello world!'); // error: You should use the "log" method of the AngularJS Service $log instead of the console object
+
+//Good:
+$log.log('Hello world!');
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/log.md)

--- a/src/main/resources/docs/description/angular_module-dependency-order.md
+++ b/src/main/resources/docs/description/angular_module-dependency-order.md
@@ -1,0 +1,13 @@
+Require a consistent order of module dependencies
+
+Module dependencies should be sorted in a logical manner. This rule provides two ways to sort modules, grouped or ungrouped. In grouped mode the modules should be grouped in the order: standard modules - third party modules - custom modules. The modules should be sorted alphabetically within its group. A prefix can be specified to determine which prefix the custom modules have. Without grouped set to false all dependencies combined should be sorted alphabetically. ('module-dependency-order', [2, {grouped: true, prefix: "app"}])
+
+```
+//Bad:
+angular.module('myModule', ['ngRoute', 'ngAnimate']); // error: ngAnimate should be sorted before ngRoute
+
+//Good:
+angular.module('myModule', ['ngAnimate', 'ngRoute', 'app', 'appFilters', 'ui.router']);
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/module-dependency-order.md)

--- a/src/main/resources/docs/description/angular_module-getter.md
+++ b/src/main/resources/docs/description/angular_module-getter.md
@@ -1,0 +1,19 @@
+Enforce to reference modules with the getter syntax.
+
+When using a module, avoid using a variable and instead use chaining with the getter syntax
+
+Rule based on Angular 1.x
+
+```
+//Bad:
+app.controller('MyController', function () {
+    // ...
+}); // error: Avoid using a variable and instead use chaining with the getter syntax.
+
+//Good:
+angular.module('myModule').controller('MyController', function () {
+    // ...
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/module-getter.md#module-getter---enforce-to-reference-modules-with-the-getter-syntax)

--- a/src/main/resources/docs/description/angular_module-name.md
+++ b/src/main/resources/docs/description/angular_module-name.md
@@ -1,0 +1,13 @@
+Require and specify a prefix for all module names
+
+When you create a new module, its name should start with the parameter you can define in your config object. The second parameter can be a Regexp wrapped in quotes. You can not prefix your modules by "ng" (reserved keyword for AngularJS modules) ("module-name": [2, "ng"])
+
+```
+//Bad:
+angular.module('otherModule', []); // error: The otherModule module should follow this pattern: /^xyz/
+
+//Good:
+angular.module('prefixModule', []);
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/module-name.md)

--- a/src/main/resources/docs/description/angular_module-setter.md
+++ b/src/main/resources/docs/description/angular_module-setter.md
@@ -1,0 +1,13 @@
+Disallow to assign modules to variables
+
+Declare modules without a variable using the setter syntax.
+
+```
+//Bad:
+var app = angular.module('myModule', []); // error: Declare modules without a variable using the setter syntax.
+
+//Good:
+angular.module('myModule', [])
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/module-setter.md)

--- a/src/main/resources/docs/description/angular_no-angular-mock.md
+++ b/src/main/resources/docs/description/angular_no-angular-mock.md
@@ -1,0 +1,15 @@
+Require to use angular.mock methods directly
+
+All methods defined in the angular.mock object are also available in the object window. So you can remove angular.mock from your code
+
+```
+//Bad:
+angular.mock.dump($scope); // error: You should use the "dump" method available in the window object.
+
+//Good:
+inject(function (someService) {
+    // ...
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/no-angular-mock.md)

--- a/src/main/resources/docs/description/angular_no-controller.md
+++ b/src/main/resources/docs/description/angular_no-controller.md
@@ -1,0 +1,22 @@
+Disallow use of controllers (according to the component first pattern)
+
+According to the Component-First pattern, we should avoid the use of AngularJS controller.
+
+```
+//Bad:
+angular.module('myModule').controller('HelloWorldController', function ($scope) {
+    $scope.text = 'Hello World';
+}); // error: Based on the Component-First Pattern, you should avoid the use of controllers
+
+//Good:
+angular.module('myModule').directive('helloWorld', function () {
+    return {
+        template: '<div>{{ text }}',
+        controller: function ($scope) {
+            $scope.text = 'Hello World';
+        }
+    };
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/no-controller.md)

--- a/src/main/resources/docs/description/angular_no-cookiestore.md
+++ b/src/main/resources/docs/description/angular_no-cookiestore.md
@@ -1,0 +1,13 @@
+Use $cookies instead of $cookieStore
+
+In Angular 1.4, the $cookieStore service is now deprected. Please use the $cookies service instead
+
+```
+//Bad:
+$cookieStore.put('favoriteMeal', 'pizza'); // error: Since Angular 1.4, the $cookieStore service is deprecated. Please use now the $cookies service.
+
+//Good:
+$cookies.put('favoriteMeal', 'pizza');
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/no-cookiestore.md)

--- a/src/main/resources/docs/description/angular_no-directive-replace.md
+++ b/src/main/resources/docs/description/angular_no-directive-replace.md
@@ -1,0 +1,24 @@
+Disallow the deprecated directive replace property
+
+This rule disallows the replace attribute in a directive definition object. The replace property of a directive definition object is deprecated since angular 1.3.
+
+The option ignoreReplaceFalse let you ignore directive definitions with replace set to false.
+
+```
+//Bad:
+angular.module('myModule').directive('helloWorld', function() {
+    return {
+        template: '<h2>Hello World!</h2>',
+        replace: true
+    };
+}); // error: Directive definition property replace is deprecated.
+
+//Good:
+angular.module('myModule').directive('helloWorld', function() {
+    return {
+        template: '<h2>Hello World!</h2>'
+    };
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/no-directive-replace.md)

--- a/src/main/resources/docs/description/angular_no-http-callback.md
+++ b/src/main/resources/docs/description/angular_no-http-callback.md
@@ -1,0 +1,19 @@
+Disallow the $http methods success() and error()
+
+Disallow the $http success and error function. Instead the standard promise API should be used.
+
+```
+//Bad:
+$http.get('api/data').success(function onSuccess() {
+    // ...
+}); // error: $http success is deprecated. Use then instead
+
+//Good:
+$http.get('api/data').then(function onSuccess() {
+    // ...
+}, function onReject() {
+   // ...
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/no-http-callback.md)

--- a/src/main/resources/docs/description/angular_no-inline-template.md
+++ b/src/main/resources/docs/description/angular_no-inline-template.md
@@ -1,0 +1,21 @@
+Disallow the use of inline templates
+
+Instead of using inline HTML templates, it is better to load the HTML from an external file. Simple HTML templates are accepted by default. ('no-inline-template': [0, {allowSimple: true}])
+
+```
+//Bad:
+angular.module('myModule').directive('helloWorld', function () {
+    return {
+        template: '<div>Hello World! <button>Say hello!</button></div>'
+    };
+}); // error: Inline template is too complex. Use an external template instead
+
+//Good:
+angular.module('myModule').directive('helloWorld', function () {
+    return {
+        templateUrl: 'template/helloWorld.html'
+    };
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/no-inline-template.md)

--- a/src/main/resources/docs/description/angular_no-jquery-angularelement.md
+++ b/src/main/resources/docs/description/angular_no-jquery-angularelement.md
@@ -1,0 +1,13 @@
+Disallow to wrap angular.element objects with jQuery or $
+
+You should not wrap angular.element object into jQuery(), because angular.element already return jQLite element
+
+```
+//Bad:
+$(angular.element("#id")) // error: angular.element returns already a jQLite element. No need to wrap with the jQuery object
+
+//Good:
+angular.element("#id")
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/no-jquery-angularelement.md)

--- a/src/main/resources/docs/description/angular_no-private-call.md
+++ b/src/main/resources/docs/description/angular_no-private-call.md
@@ -1,0 +1,16 @@
+Disallow use of internal angular properties prefixed with $$
+
+All scope's properties/methods starting with $$ are used internally by AngularJS. You should not use them directly. 
+Exception can be allowed with this option: {allow:['$$watchers']}
+
+```
+//Bad:
+$scope.$$watchers.forEach(function (watcher) {
+    // ...
+}); // error: Using $$-prefixed Angular objects/methods are not recommended
+
+//Good:
+$scope.$apply();
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/no-private-call.md)

--- a/src/main/resources/docs/description/angular_no-run-logic.md
+++ b/src/main/resources/docs/description/angular_no-run-logic.md
@@ -1,0 +1,20 @@
+Keep run functions clean and simple
+
+Initialization logic should be moved into a factory or service. This improves testability.
+
+```
+//Bad:
+angular.module('app').run(function($window) {
+    $window.addEventListener('deviceready', deviceready);
+
+    function deviceready() {}
+}); // error: The run function may only contain call expressions
+
+//Good:
+angular.module('app').run(function(KITTENS, kittenService, startup) {
+    kittenService.prefetchData(KITTENS);
+    startup('foo', true, 1);
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/no-run-logic.md)

--- a/src/main/resources/docs/description/angular_no-service-method.md
+++ b/src/main/resources/docs/description/angular_no-service-method.md
@@ -1,0 +1,15 @@
+You should prefer the factory() method instead of service()
+
+```
+//Bad:
+angular.module('myModule').service('myService', function() {
+    // ...
+}); // error: You should prefer the factory() method instead of service()
+
+//Good:
+angular.module('myModule').factory('myService', function () {
+    // ...
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/no-service-method.md)

--- a/src/main/resources/docs/description/angular_no-services.md
+++ b/src/main/resources/docs/description/angular_no-services.md
@@ -1,0 +1,17 @@
+Disallow DI of specified services
+
+Some services should be used only in a specific AngularJS service (Ajax-based service for example), in order to follow the separation of concerns paradigm. The second parameter specifies the services. The third parameter can be a list of angular objects (controller, factory, etc.). Or second parameter can be an object, where keys are angular object names and value is a list of services (like {controller: ['$http'], factory: ['$q']})
+
+```
+//Bad:
+app.controller('MyController', function($http) {
+    // ...
+}); // error: REST API calls should be implemented in a specific service ($http in controller)
+
+//Good:
+app.controller('MyController', function(myService) {
+    // ...
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/no-services.md)

--- a/src/main/resources/docs/description/angular_on-destroy.md
+++ b/src/main/resources/docs/description/angular_on-destroy.md
@@ -1,0 +1,17 @@
+Check for common misspelling $on('destroy', ...).
+
+It should be $on('$destroy', ...).
+
+```
+//Bad:
+$rootScope.$on('destroy', function () {
+    // ...
+}); // error: You probably misspelled $on("$destroy").
+
+//Good:
+$scope.$on('$destroy', function () {
+    // ...
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/on-destroy.md)

--- a/src/main/resources/docs/description/angular_on-watch.md
+++ b/src/main/resources/docs/description/angular_on-watch.md
@@ -1,0 +1,17 @@
+Require $on and $watch deregistration callbacks to be saved in a variable
+
+Watch and On methods on the scope object should be assigned to a variable, in order to be deleted in a $destroy event handler
+
+```
+//Bad:
+$rootScope.$on('event', function () {
+    // ...
+}); // error: The "$on" call should be assigned to a variable, in order to be destroyed during the $destroy event
+
+//Good:
+$scope.$on('event', function () {
+    // ...
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/on-watch.md)

--- a/src/main/resources/docs/description/angular_one-dependency-per-line.md
+++ b/src/main/resources/docs/description/angular_one-dependency-per-line.md
@@ -1,0 +1,15 @@
+Require all DI parameters to be located in their own line
+
+Injected dependencies should be written one per line.
+
+```
+//Bad:
+function MyController($http, $q) {} // error: Do not use multiple dependencies in one line
+
+//Good:
+function MyController($http,
+                      $q) {
+}
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/one-dependency-per-line.md)

--- a/src/main/resources/docs/description/angular_prefer-component.md
+++ b/src/main/resources/docs/description/angular_prefer-component.md
@@ -1,0 +1,17 @@
+Since AngularJS 1.5, we can use a new API when creating directives. This new API should be use when creating directive without DOM manipulation.
+
+```
+//Bad:
+angular.module('myModule').directive('helloWorld', function() {
+    return {
+
+    }
+}); // error: Directive should be implemented with the component method.
+
+//Good:
+angular.module('myModule').component('helloWorld', {
+    template: '<h2>Hello World!</h2>'
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/prefer-component.md)

--- a/src/main/resources/docs/description/angular_provider-name.md
+++ b/src/main/resources/docs/description/angular_provider-name.md
@@ -1,0 +1,17 @@
+Require and specify a prefix for all provider names
+
+All your providers should have a name starting with the parameter you can define in your config object. The second parameter can be a Regexp wrapped in quotes. You can not prefix your providers by "$" (reserved keyword for AngularJS services) ("provider-name": [2, "ng"]) *
+
+```
+//Bad:
+angular.module('myModule').provider('otherProvider', function () {
+    // ...
+}); // error: The otherProvider provider should follow this pattern: /^xyz/
+
+//Good:
+angular.module('myModule').provider('prefixProvider', function () {
+    // ...
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/provider-name.md)

--- a/src/main/resources/docs/description/angular_rest-service.md
+++ b/src/main/resources/docs/description/angular_rest-service.md
@@ -1,0 +1,17 @@
+Disallow different rest service and specify one of '$http', '$resource', 'Restangular'
+
+Check the service used to send request to your REST API. This rule can have one parameter, with one of the following values: $http, $resource or Restangular ('rest-service': [0, '$http']).
+
+```
+//Bad:
+angular.module('myModule').service('myService', function($resource) {
+    // ...
+}); // error: You should use the same service ($http) for REST API calls
+
+//Good:
+angular.module('myModule').service('myService', function($http) {
+    // ...
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/rest-service.md)

--- a/src/main/resources/docs/description/angular_service-name.md
+++ b/src/main/resources/docs/description/angular_service-name.md
@@ -1,0 +1,19 @@
+Require and specify a prefix for all service names
+
+All your services should have a name starting with the parameter you can define in your config object. The second parameter can be a Regexp wrapped in quotes. You can not prefix your services by "$" (reserved keyword for AngularJS services) ("service-name": [2, "ng"])
+
+If the oldBehavior is true (default value), this rule will check the name of all services defined with the different methods provided by the framework : provider, service, factory, ... If this parameter is false, only services defined with the service method will be checked.
+
+```
+//Bad:
+angular.module('myModule').service('otherService', function () {
+    // ...
+}); // error: The otherService service should follow this pattern: /^xyz/
+
+//Good:
+angular.module('myModule').service('prefixService', function () {
+    // ...
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/service-name.md)

--- a/src/main/resources/docs/description/angular_timeout-service.md
+++ b/src/main/resources/docs/description/angular_timeout-service.md
@@ -1,0 +1,18 @@
+Use $timeout instead of setTimeout
+
+Instead of the default setTimeout function, you should use the AngularJS wrapper service $timeout *
+
+```
+//Bad:
+setTimeout(function() {
+    // ...
+}, 1000) // error: You should use the $timeout service instead of the default window.setTimeout method
+
+//Good:
+$timeout(function() {
+    // ...
+}, 1000)
+
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/timeout-service.md)

--- a/src/main/resources/docs/description/angular_typecheck-array.md
+++ b/src/main/resources/docs/description/angular_typecheck-array.md
@@ -1,0 +1,13 @@
+Use angular.isArray instead of typeof comparisons
+
+You should use the angular.isArray method instead of the default JavaScript implementation (typeof [] === "[object Array]").
+
+```
+//Bad:
+Object.prototype.toString.call(someArray) === '[object Array]'; // error: You should use the angular.isArray method
+
+//Good:
+Array.isArray(someArray) // error: You should use the angular.isArray method
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/typecheck-array.md)

--- a/src/main/resources/docs/description/angular_typecheck-date.md
+++ b/src/main/resources/docs/description/angular_typecheck-date.md
@@ -1,0 +1,13 @@
+Use angular.isDate instead of typeof comparisons
+
+You should use the angular.isDate method instead of the default JavaScript implementation (typeof new Date() === "[object Date]").
+
+```
+//Bad:
+Object.prototype.toString.call(someDate) === '[object Date]'; // error: You should use the angular.isDate method
+
+//Good:
+angular.isDate(someDate);
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/typecheck-date.md)

--- a/src/main/resources/docs/description/angular_typecheck-function.md
+++ b/src/main/resources/docs/description/angular_typecheck-function.md
@@ -1,0 +1,13 @@
+Use angular.isFunction instead of typeof comparisons
+
+You should use the angular.isFunction method instead of the default JavaScript implementation (typeof function(){} ==="[object Function]").
+
+```
+//Bad:
+typeof someFunction === 'function' // error: You should use the angular.isFunction method
+
+//Good:
+angular.isFunction(someFunction);
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/typecheck-function.md)

--- a/src/main/resources/docs/description/angular_typecheck-number.md
+++ b/src/main/resources/docs/description/angular_typecheck-number.md
@@ -1,0 +1,13 @@
+Use angular.isNumber instead of typeof comparisons
+
+You should use the angular.isNumber method instead of the default JavaScript implementation (typeof 3 === "[object Number]").
+
+```
+//Bad:
+typeof someNumber === 'number' // error: You should use the angular.isNumber method
+
+//Good:
+angular.isNumber(someNumber);
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/typecheck-number.md)

--- a/src/main/resources/docs/description/angular_typecheck-object.md
+++ b/src/main/resources/docs/description/angular_typecheck-object.md
@@ -1,0 +1,13 @@
+Use angular.isObject instead of typeof comparisons
+
+You should use the angular.isObject method instead of the default JavaScript implementation (typeof {} === "[object Object]").
+
+```
+//Bad:
+typeof someObject === 'object' // error: You should use the angular.isObject method
+
+//Good:
+angular.isObject(someObject);
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/typecheck-object.md)

--- a/src/main/resources/docs/description/angular_typecheck-string.md
+++ b/src/main/resources/docs/description/angular_typecheck-string.md
@@ -1,0 +1,13 @@
+Use angular.isString instead of typeof comparisons
+
+You should use the angular.isString method instead of the default JavaScript implementation (typeof "" === "[object String]").
+
+```
+//Bad:
+typeof someString === 'string' // error: You should use the angular.isString method
+
+//Good:
+angular.isString(someString);
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/typecheck-string.md)

--- a/src/main/resources/docs/description/angular_value-name.md
+++ b/src/main/resources/docs/description/angular_value-name.md
@@ -1,0 +1,17 @@
+Require and specify a prefix for all value names
+
+All your values should have a name starting with the parameter you can define in your config object. The second parameter can be a Regexp wrapped in quotes. You can not prefix your values by "$" (reserved keyword for AngularJS services) ("value-name": [2, "ng"])
+
+```
+//Bad:
+angular.module('myModule').value('otherValue', function () {
+    // ...
+}); // error: The otherValue value should follow this pattern: /^xyz/
+
+//Good:
+angular.module('myModule').value('prefixValue', function () {
+    // ...
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/value-name.md)

--- a/src/main/resources/docs/description/angular_watchers-execution.md
+++ b/src/main/resources/docs/description/angular_watchers-execution.md
@@ -1,0 +1,15 @@
+Require and specify consistent use $scope.digest() or $scope.apply()
+
+For the execution of the watchers, the $digest method will start from the scope in which we call the method. This will cause an performance improvement comparing to the $apply method, who start from the $rootScope
+
+```
+//Bad:
+$scope.$digest(); // error: Instead of using the $digest() method, you should prefer $apply()
+
+//Good:
+$scope.$apply(function() {
+    // ...
+});
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/watchers-execution.md)

--- a/src/main/resources/docs/description/angular_window-service.md
+++ b/src/main/resources/docs/description/angular_window-service.md
@@ -1,0 +1,13 @@
+Use $window instead of window
+
+Instead of the default window object, you should prefer the AngularJS wrapper service $window.
+
+```
+//Bad:
+window.alert('Hello world!'); // error: You should use the $window service instead of the default window object
+
+//Good:
+$window.alert('Hello world!');
+```
+
+[Source](https://github.com/EmmanuelDemey/eslint-plugin-angular/blob/HEAD/docs/rules/window-service.md)

--- a/src/main/resources/docs/description/collection-ordering.md
+++ b/src/main/resources/docs/description/collection-ordering.md
@@ -1,0 +1,32 @@
+Lodash has two methods for sorting a collection by a specific order: sortBy and orderBy. Both methods accept one or several iteratees, but orderBy also accepts an optional parameter whether the order is ascending or descending. This means that ordering any array by ascending order can be done in several different ways:
+
+```
+var users = [
+  { 'user': 'fred',   'age': 48 },
+  { 'user': 'barney', 'age': 34 },
+  { 'user': 'fred',   'age': 40 },
+  { 'user': 'barney', 'age': 36 }
+]
+
+_.sortBy(users, 'age')
+_.orderBy(users, 'age')
+_.orderBy(users, ['age'], ['asc'])
+_.orderBy(users, 'age', 'asc')
+```
+
+When method is sortBy
+```
+//Bad:
+_.orderBy(arr, [f])
+_.orderBy(arr, ["name"])
+_.orderBy(arr, [f], ["asc"])
+
+//Good:
+_.sortBy(arr, [f])
+_.sortBy(arr, ['name'])
+_.orderBy(arr, ['name'], ['desc']
+```
+
+See source for further examples
+
+[Source](https://github.com/wix/eslint-plugin-lodash/blob/4673524ad4d7397c38feaad8ff72ff141af8810f/docs/rules/collection-ordering.md)

--- a/src/main/resources/docs/description/description.json
+++ b/src/main/resources/docs/description/description.json
@@ -1,5 +1,11 @@
 [
   {
+    "patternId": "no-promise-without-done-fail",
+    "title": "No promise without done fail",
+    "description": "Make sure that all uses of the promises include a catch(done.fail) within a suite.",
+    "timeToFix": 5
+  },
+  {
     "patternId": "angular_typecheck-string",
     "title": "AngularJS - Typecheck string",
     "description": "You should use the angular.isString method instead of the default JavaScript implementation.",

--- a/src/main/resources/docs/description/description.json
+++ b/src/main/resources/docs/description/description.json
@@ -1,5 +1,359 @@
 [
   {
+    "patternId": "angular_typecheck-string",
+    "title": "AngularJS - Typecheck string",
+    "description": "You should use the angular.isString method instead of the default JavaScript implementation.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_typecheck-object",
+    "title": "AngularJS - Typecheck object",
+    "description": "You should use the angular.isObject method instead of the default JavaScript implementation.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_typecheck-number",
+    "title": "AngularJS - Typecheck number",
+    "description": "You should use the angular.isNumber method instead of the default JavaScript implementation.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_typecheck-function",
+    "title": "AngularJS - Typecheck function",
+    "description": "You should use the angular.isFunction method instead of the default JavaScript implementation.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_typecheck-date",
+    "title": "AngularJS - Typecheck date",
+    "description": "You should use the angular.isDate method instead of the default JavaScript implementation.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_typecheck-array",
+    "title": "AngularJS - Typecheck array",
+    "description": "You should use the angular.isArray method instead of the default JavaScript implementation.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_on-destroy",
+    "title": "AngularJS - On destroy spell check",
+    "description": "Check for common misspelling $on('destroy', ...).",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_window-service",
+    "title": "AngularJS - Window service",
+    "description": "Instead of the default window object, you should prefer the AngularJS wrapper service $window.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_timeout-service",
+    "title": "AngularJS - Timeout service",
+    "description": "Instead of the default setTimeout function, you should use the AngularJS wrapper service $timeout.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_no-jquery-angularelement",
+    "title": "AngularJS - No angular mock",
+    "description": "Require to use angular.mock methods directly.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_no-angular-mock",
+    "title": "AngularJS - No angular mock",
+    "description": "Require to use angular.mock methods directly.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_log",
+    "title": "AngularJS - Log",
+    "description": "Use $log service instead of console for the methods 'log', 'debug', 'error', 'info', 'warn'.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_json-functions",
+    "title": "AngularJS - Interval service",
+    "description": "Instead of the default setInterval function, you should use the AngularJS wrapper service $interval",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_interval-service",
+    "title": "AngularJS - Interval service",
+    "description": "Instead of the default setInterval function, you should use the AngularJS wrapper service $interval",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_foreach",
+    "title": "AngularJS - Foreach",
+    "description": "use the angular.forEach method instead of the default JavaScript implementation [].forEach.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_document-service",
+    "title": "AngularJS - Document service",
+    "description": "Instead of the default document object, you should prefer the AngularJS wrapper service $document.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_definedundefined",
+    "title": "AngularJS - Defined undefined",
+    "description": "Use the angular.isUndefined or angular.isDefined methods instead of using the keyword undefined",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_angularelement",
+    "title": "AngularJS - Angular element",
+    "description": "The angular.element method should be used instead of the $ or jQuery object",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_watchers-execution",
+    "title": "AngularJS - Watchers execution",
+    "description": "Require and specify consistent use $scope.digest() or $scope.apply()",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_rest-service",
+    "title": "AngularJS - No different rest services",
+    "description": "Disallow different rest service and specify one of '$http', '$resource', 'Restangular'.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_one-dependency-per-line",
+    "title": "AngularJS - No service method",
+    "description": "Require all DI parameters to be located in their own line.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_no-service-method",
+    "title": "AngularJS - No service method",
+    "description": "You should prefer the factory() method instead of service().",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_module-dependency-order",
+    "title": "AngularJS - Module Dependency Order",
+    "description": "Require a consistent order of module dependencies.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_function-type",
+    "title": "AngularJS - Function type",
+    "description": "Require and specify a consistent function style for components.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_dumb-inject",
+    "title": "AngularJS - Dumb inject",
+    "description": "Unit test inject functions should only consist of assignments from injected values to describe block variables.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_di",
+    "title": "AngularJS - DI",
+    "description": "Require a consistent DI syntax.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_di-order",
+    "title": "AngularJS - DI Order",
+    "description": "Require DI parameters to be sorted alphabetically.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_value-name",
+    "title": "AngularJS - Value name",
+    "description": "Require and specify a prefix for all value names.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_service-name",
+    "title": "AngularJS - Service name",
+    "description": "Require and specify a prefix for all service names.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_provider-name",
+    "title": "AngularJS - Provider name",
+    "description": "Require and specify a prefix for all provider names.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_module-name",
+    "title": "AngularJS - Module name",
+    "description": "Require and specify a prefix for all module names.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_filter-name",
+    "title": "AngularJS - Filter name",
+    "description": "Require and specify a prefix for all filter names.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_file-name",
+    "title": "AngularJS - File name",
+    "description": "Require and specify a consistent component name pattern.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_factory-name",
+    "title": "AngularJS - Factory name",
+    "description": "Require and specify a prefix for all factory names.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_directive-name",
+    "title": "AngularJS - Directive name",
+    "description": "Require and specify a prefix for all directive names.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_controller-name",
+    "title": "AngularJS - Controller name",
+    "description": "Require and specify a prefix for all controller names.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_constant-name",
+    "title": "AngularJS - Constant name",
+    "description": "Require and specify a prefix for all constant names.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_component-name",
+    "title": "AngularJS - Component name",
+    "description": "Require and specify a prefix for all component names.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_no-http-callback",
+    "title": "AngularJS - No HTTP callback",
+    "description": "Disallow the $http success and error function.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_no-directive-replace",
+    "title": "AngularJS - Disallow the deprecated directive replace property",
+    "description": "This rule disallows the replace attribute in a directive definition object.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_no-cookiestore",
+    "title": "AngularJS - No cookiesstore",
+    "description": "In Angular 1.4, the $cookieStore service is now deprected.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_prefer-component",
+    "title": "AngularJS - Prefer component",
+    "description": "Since AngularJS 1.5, we can use a new API when creating directives.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_on-watch",
+    "title": "AngularJS - On watch",
+    "description": "Watch and On methods on the scope object should be assigned to a variable.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_no-services",
+    "title": "AngularJS - Disallow DI of specified services",
+    "description": "Some services should be used only in a specific AngularJS service (Ajax-based service for example).",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_no-run-logic",
+    "title": "AngularJS - Keep run functions clean and simple",
+    "description": "Initialization logic should be moved into a factory or service.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_no-inline-template",
+    "title": "AngularJS - Disallow the use of inline templates",
+    "description": "Instead of using inline HTML templates, it is better to load the HTML from an external file.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_no-controller",
+    "title": "AngularJS - Disallow use of controllers",
+    "description": "According to the Component-First pattern, we should avoid the use of AngularJS controller.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_empty-controller",
+    "title": "AngularJS - Disallow empty controllers",
+    "description": "If you have one empty controller, maybe you have linked it in your Router configuration or in one of your views.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_directive-restrict",
+    "title": "AngularJS - disallow any other directive restrict than 'A' or 'E'",
+    "description": "Not all directive restrictions may be desirable.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_di-unused",
+    "title": "AngularJS - disallow unused DI parameters",
+    "description": "Unused dependencies should not be injected.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_deferred",
+    "title": "AngularJS - Use $q(function(resolve, reject){}) instead of $q.deferred",
+    "description": "When you want to create a new promise, you should not use the $q.deferred anymore.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_controller-as",
+    "title": "AngularJS - Disallow assignments to $scope in controllers",
+    "description": "You should not set properties on $scope in controllers.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_controller-as-vm",
+    "title": "AngularJS - Require and specify a capture variable for this in controllers",
+    "description": "You should use a capture variable for 'this' when using the controllerAs syntax.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_controller-as-route",
+    "title": "AngularJS - Require the use of controllerAs in routes or states",
+    "description": "You should use Angular's controllerAs syntax when defining routes or states.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_component-limit",
+    "title": "AngularJS - Limit the number of angular components per file",
+    "description": "The number of AngularJS components in one file should be limited. The default limit is one.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_no-private-call",
+    "title": "AngularJS - Disallow use of internal angular properties prefixed with $$",
+    "description": "All scope's properties/methods starting with $$ are used internally by AngularJS.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_module-setter",
+    "title": "AngularJS - Disallow to assign modules to variables",
+    "description": "Declare modules without a variable using the setter syntax.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_module-getter",
+    "title": "AngularJS - Enforce to reference modules with the getter syntax",
+    "description": "When using a module, avoid using a variable and instead use chaining with the getter syntax.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "angular_avoid-scope-typos",
+    "title": "AngularJS - Avoid mistakes when naming methods defined on the scope object",
+    "description": "For example, you want to use $scope.$watch instead of $scope.watch.",
+    "timeToFix": 5
+  },
+  {
     "patternId": "no-assigning-return-values",
     "title": "No Assigning return values",
     "description": "You rarely have to ever use const, let, or var in Cypress. If you’re using them, it’s usually a sign you’re doing it wrong.",

--- a/src/main/resources/docs/description/description.json
+++ b/src/main/resources/docs/description/description.json
@@ -1,5 +1,17 @@
 [
   {
+    "patternId": "no-setup-in-describe",
+    "title": "Disallow setup in describe blocks",
+    "description": "Looks for all function calls and use of the dot operator which are nested directly in a describe block.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "no-async-describe",
+    "title": "Disallow async functions passed to describe",
+    "description": "Disallows the use of an async function with describe.",
+    "timeToFix": 5
+  },
+  {
     "patternId": "collection-ordering",
     "title": "Collection Ordering",
     "description": "Lodash has two methods for sorting a collection by a specific order: sortBy and orderBy.",

--- a/src/main/resources/docs/description/description.json
+++ b/src/main/resources/docs/description/description.json
@@ -1,5 +1,33 @@
 [
   {
+    "patternId": "collection-ordering",
+    "title": "Collection Ordering",
+    "description": "Lodash has two methods for sorting a collection by a specific order: sortBy and orderBy.",
+    "timeToFix": 5,
+    "parameters": [
+      {
+        "name": "method",
+        "description": "Which method should be used for ordering [sortBy, orderBy, orderByExplicit]"
+      },
+      {
+        "name": "useArray",
+        "description": "When to wrap the iterates and orders in arrays [always, as-needed]"
+      }
+    ]
+  },
+  {
+    "patternId": "prefer-find",
+    "title": "Prefer find",
+    "description": "Prefer _.find over _.filter followed by selecting the first result.",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "prefer-immutable-method",
+    "title": "Prefer immutable methods",
+    "description": "Prefer a method that doesn't mutate the arguments when available.",
+    "timeToFix": 5
+  },
+  {
     "patternId": "no-promise-without-done-fail",
     "title": "No promise without done fail",
     "description": "Make sure that all uses of the promises include a catch(done.fail) within a suite.",

--- a/src/main/resources/docs/description/no-async-describe.md
+++ b/src/main/resources/docs/description/no-async-describe.md
@@ -1,0 +1,23 @@
+Disallow async functions passed to describe (no-async-describe)
+
+This rule disallows the use of an async function with describe. It usually indicates a copy/paste error or that you're trying to use describe for setup code, which should happen in before or beforeEach. Also, it can lead to the contained it blocks not being picked up.
+
+```
+//Bad:
+describe('something', async function () {
+    it('should work', function () {});
+});
+
+describe('something', async () => {
+    it('should work', function () {});
+});
+
+//Good:
+async function mySuite() {
+    it('my test', () => {});
+}
+
+describe('my suite', mySuite);
+```
+
+[Source](https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-async-describe.md)

--- a/src/main/resources/docs/description/no-promise-without-done-fail.md
+++ b/src/main/resources/docs/description/no-promise-without-done-fail.md
@@ -1,0 +1,24 @@
+Disallow using promise without a done.fail (no-promise-without-done-fail).
+
+Make sure that all uses of the promises include a catch(done.fail) within a suite.
+
+```
+//Bad:
+describe('A suite', function(done) {
+  it('A spec', function() {
+    asyncCall().then(done);
+  });
+});
+
+//Good:
+describe('A suite', function(done) {
+  it('A spec', function() {
+    asyncCall().then(function() {
+      expect(true).toBe(true);
+      done();
+    }).catch(done.fail);
+  });
+});
+```
+
+[Source](https://github.com/tlvince/eslint-plugin-jasmine/blob/9bd0f76eefa22ae8e04658bc598b6d404379121d/docs/rules/no-promise-without-done-fail.md)

--- a/src/main/resources/docs/description/no-setup-in-describe.md
+++ b/src/main/resources/docs/description/no-setup-in-describe.md
@@ -1,0 +1,30 @@
+Disallow setup in describe blocks (no-setup-in-describe)
+
+Setup for test cases in mocha should be done in before, beforeEach, or it blocks. Unfortunately there is nothing stopping you from doing setup directly inside a describe block.
+
+Any setup directly in a describe is run before all tests execute. This is undesirable primarily for two reasons:
+
+When doing TDD in a large codebase, all setup is run for tests that don't have only set. This can add a substantial amount of time per iteration.
+If global state is altered by the setup of another describe block, your test may be affected.
+This rule reports all function calls and use of the dot operator (due to getters and setters) directly in describe blocks.
+
+If you're using dynamically generated tests, you should disable this rule.
+
+```
+//Bad:
+describe('something', function () {
+    let a = b.c;
+    it('should work', function () {});
+});
+
+//Good:
+describe('something', function () {
+    var a;
+    beforeEach(function() {
+        a = setup();
+    });
+    it('should work', function () {});
+});
+```
+
+[Source](https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-setup-in-describe.md)

--- a/src/main/resources/docs/description/prefer-find.md
+++ b/src/main/resources/docs/description/prefer-find.md
@@ -1,0 +1,13 @@
+When using _.filter and accessing the first or last result, you should probably use _.find or _.findLast, respectively.
+
+```
+//Bad:
+const x = _.filter(a, f)[0];
+const x = _.head(_.filter(a, f));
+
+//Good:
+const x = _.filter(a, f);
+const x = _.filter(a, f)[3];
+```
+
+[Source](https://github.com/wix/eslint-plugin-lodash/blob/c81ef24cbe8cfa5f9fa27a31da9301a53f240ef0/docs/rules/prefer-find.md)

--- a/src/main/resources/docs/description/prefer-immutable-method.md
+++ b/src/main/resources/docs/description/prefer-immutable-method.md
@@ -1,0 +1,13 @@
+Prefer a method that doesn't mutate the arguments when available.
+
+```
+//Bad:
+_.pull(arr, value)
+const a = _.remove(arr, fn);
+
+//Good:
+const a = _.without(arr, value);
+const a = _.filter(arr, fn);
+```
+
+[Source](https://github.com/wix/eslint-plugin-lodash/blob/c4fe9cd709385b394c8b6418d958c3c266f953b7/docs/rules/prefer-immutable-method.md)

--- a/src/main/resources/docs/patterns.json
+++ b/src/main/resources/docs/patterns.json
@@ -3,6 +3,11 @@
   "version": "5.16.0",
   "patterns": [
     {
+      "patternId": "no-promise-without-done-fail",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
       "patternId": "angular_typecheck-string",
       "level": "Info",
       "category": "CodeStyle"

--- a/src/main/resources/docs/patterns.json
+++ b/src/main/resources/docs/patterns.json
@@ -3,6 +3,16 @@
   "version": "5.16.0",
   "patterns": [
     {
+      "patternId": "no-setup-in-describe",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "no-async-describe",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
       "patternId": "collection-ordering",
       "level": "Info",
       "category": "CodeStyle",

--- a/src/main/resources/docs/patterns.json
+++ b/src/main/resources/docs/patterns.json
@@ -3,6 +3,301 @@
   "version": "5.16.0",
   "patterns": [
     {
+      "patternId": "angular_typecheck-string",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_typecheck-object",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_typecheck-number",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_typecheck-function",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_typecheck-date",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_typecheck-array",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_on-destroy",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_window-service",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_timeout-service",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_no-jquery-angularelement",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_no-angular-mock",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_log",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_json-functions",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_interval-service",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_foreach",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_document-service",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_definedundefined",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_angularelement",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_watchers-execution",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_rest-service",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_one-dependency-per-line",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_no-service-method",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_module-dependency-order",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_function-type",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_dumb-inject",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_di",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_di-order",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_value-name",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_service-name",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_provider-name",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_module-name",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_filter-name",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_file-name",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_factory-name",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_directive-name",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_controller-name",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_constant-name",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_component-name",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_no-http-callback",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_no-directive-replace",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_no-cookiestore",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_prefer-component",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_on-watch",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_no-services",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_no-run-logic",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_no-inline-template",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_no-controller",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_empty-controller",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_directive-restrict",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_di-unused",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_deferred",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_controller-as",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_controller-as-vm",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_controller-as-route",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_component-limit",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_no-private-call",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_module-setter",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_module-getter",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "angular_avoid-scope-typos",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
       "patternId": "no-assigning-return-values",
       "level": "Info",
       "category": "CodeStyle"

--- a/src/main/resources/docs/patterns.json
+++ b/src/main/resources/docs/patterns.json
@@ -3,6 +3,31 @@
   "version": "5.16.0",
   "patterns": [
     {
+      "patternId": "collection-ordering",
+      "level": "Info",
+      "category": "CodeStyle",
+      "parameters": [
+        {
+          "name": "method",
+          "default": "sortBy"
+        },
+        {
+          "name": "useArray",
+          "default": "always"
+        }
+      ]
+    },
+    {
+      "patternId": "prefer-find",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
+      "patternId": "prefer-immutable-method",
+      "level": "Info",
+      "category": "CodeStyle"
+    },
+    {
       "patternId": "no-promise-without-done-fail",
       "level": "Info",
       "category": "CodeStyle"


### PR DESCRIPTION
This PR updates the leftover packages from (#133). All packages are now at their latest versions with the exception of `eslint-plugin-node` due to the size of the update. This will be undertaken in a future PR. 

A total of 64 new rules have been documented. 

The packages have been sorted alphabetically for ease of maintenance. 