### PR TITLE
Add vue-eslint-parser

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,6 +50,7 @@ def installAll(toolVersion: String) =
      |npm install -g typescript@3.5.1 &&
      |npm install -g webpack@4.33.0 &&
      |npm install -g babel-eslint@10.0.1 &&
+     |npm install -g vue-eslint-parser@6.0.4 &&
      |npm install -g eslint@$toolVersion &&
      |npm install -g eslint-config-airbnb@17.1.0 &&
      |npm install -g eslint-config-airbnb-base@13.1.0 &&


### PR DESCRIPTION
This package is a dependency of `eslint-plugin-vue` and it's apparently not being installed as a dependency of it.

This is what we see when running a project that makes use of `eslint-plugin-vue`:

```
ESLint exited with code 2
message: Message: Premature end of file.
FileContents:

          
stdout: 
stderr: Error: Cannot find module 'vue-eslint-parser'
    at ModuleResolver.resolve (/usr/lib/node_modules/eslint/lib/util/module-resolver.js:72:19)
    at loadFromDisk (/usr/lib/node_modules/eslint/lib/config/config-file.js:537:42)
    at Object.load (/usr/lib/node_modules/eslint/lib/config/config-file.js:587:20)
    at Config.getLocalConfigHierarchy (/usr/lib/node_modules/eslint/lib/config.js:240:44)
    at Config.getConfigHierarchy (/usr/lib/node_modules/eslint/lib/config.js:192:43)
    at Config.getConfigVector (/usr/lib/node_modules/eslint/lib/config.js:299:21)
    at Config.getConfig (/usr/lib/node_modules/eslint/lib/config.js:342:29)
    at processText (/usr/lib/node_modules/eslint/lib/cli-engine.js:181:33)
    at processFile (/usr/lib/node_modules/eslint/lib/cli-engine.js:241:12)
    at fileList.map.fileInfo (/usr/lib/node_modules/eslint/lib/cli-engine.js:616:40)
                
	at codacy.eslint.ESLint$.$anonfun$apply$1(ESLint.scala:56)
	at scala.util.Try$.apply(Try.scala:213)
	at codacy.eslint.ESLint$.apply(ESLint.scala:25)
	at com.codacy.tools.scala.seed.DockerEngine.$anonfun$main$2(DockerEngine.scala:42)
	at com.codacy.tools.scala.seed.DockerEngine.$anonfun$main$2$adapted(DockerEngine.scala:28)
	at scala.util.Success.$anonfun$map$1(Try.scala:255)
	at scala.util.Success.map(Try.scala:213)
	at com.codacy.tools.scala.seed.DockerEngine.$anonfun$main$1(DockerEngine.scala:28)
	at scala.util.Success.flatMap(Try.scala:251)
	at com.codacy.tools.scala.seed.DockerEngine.main(DockerEngine.scala:27)
	at codacy.Engine.main(Engine.scala)
```
